### PR TITLE
feat: add template formatter option `bracketSpacing`

### DIFF
--- a/inspect-extension/.vscode/settings.json
+++ b/inspect-extension/.vscode/settings.json
@@ -5,5 +5,6 @@
   "mpx.format.template.wrapAttributes": "auto",
   "mpx.format.template.wrapLineLength": 80,
   // stylus 格式化配置
-  "mpx.format.style.stylus": {}
+  "mpx.format.style.stylus": {},
+  "mpx.format.template.bracketSpacing": "true"
 }

--- a/inspect-extension/components/composition/attributesCheck.mpx
+++ b/inspect-extension/components/composition/attributesCheck.mpx
@@ -4,9 +4,9 @@
       <!-- @mpx-expect-error -->
       <icon />
       <!-- ^ 缺少必填属性 `type` -->
-      <button plain="{{true}}" />
-      <swiper indicator-dots="{{indicatorDots}}" autoplay="{{autoplay}}"
-        interval="{{interval}}" duration="{{duration}}" bindtap="onSwiperChange"
+      <button plain="{{ true }}" />
+      <swiper indicator-dots="{{ indicatorDots }}" autoplay="{{ autoplay }}"
+        interval="{{ interval }}" duration="{{ duration }}" bindtap="onSwiperChange"
         bindtap1="onSwiperChange">
         <block wx:for="{{backgroundList}}" wx:key="*this">
           <swiper-item>
@@ -17,7 +17,7 @@
         </block>
       </swiper>
       <input bind:blur="inputBlur" bindfocus="inputFocus" type="number"
-        placeholder="11" placeholder-style="color: #ccc;" maxlength="{{11}}" />
+        placeholder="11" placeholder-style="color: #ccc;" maxlength="{{ 11 }}" />
     </view>
   </view>
 </template>

--- a/inspect-extension/components/composition/wxFor.mpx
+++ b/inspect-extension/components/composition/wxFor.mpx
@@ -64,7 +64,7 @@ defineExpose({
 
 <style lang="stylus">
 .list
-	background-color red
+  background-color red
 </style>
 
 <script type="application/json">

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -236,6 +236,21 @@
           "default": 120,
           "markdownDescription": "%template.format.wrapLineLength.desc%"
         },
+        "mpx.format.template.bracketSpacing": {
+          "type": "string",
+          "default": "true",
+          "enum": [
+            "true",
+            "false",
+            "preserve"
+          ],
+          "enumDescriptions": [
+            "%template.format.bracketSpacing.true%",
+            "%template.format.bracketSpacing.false%",
+            "%template.format.bracketSpacing.preserve%"
+          ],
+          "markdownDescription": "%template.format.bracketSpacing.desc%"
+        },
         "mpx.format.style.stylus": {
           "type": "object",
           "default": {},

--- a/vscode/package.nls.json
+++ b/vscode/package.nls.json
@@ -12,5 +12,9 @@
   "template.format.wrapAttributes.preserve": "保持属性的换行格式。",
   "template.format.wrapAttributes.preservealigned": "保持属性的换行格式但和第一个属性对齐。",
   "template.format.wrapLineLength.desc": "`<template>` 模块属性格式化时的最大行长度，超过此长度的属性会被换行（0 = 不换行）。",
+  "template.format.bracketSpacing.desc": "`<template>` 模板属性值花括号内的表达式前后空格的格式化方式。",
+  "template.format.bracketSpacing.true": "强制添加空格：\nattr=\"{{expr}}\" → attr=\"{{ expr }}\"。",
+  "template.format.bracketSpacing.false": "强制移除空格：\nattr=\"{{ expr }}\" → attr=\"{{expr}}\"。",
+  "template.format.bracketSpacing.preserve": "保持原有格式不变。",
   "style.stylus.format.desc": "`<style lang=\"stylus\">` 模块代码格式化配置，配置选项请参考 Stylus Supremacy 的[格式化选项](https://thisismanta.github.io/stylus-supremacy/#options)。\n\n_比如：_\n```\n\"mpx.format.style.stylus\": {\n  \"insertColons\": true,\n  \"insertSemicolons\": true\n}\n```"
 }


### PR DESCRIPTION
closes #32 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting to control spacing inside double curly braces in template attribute expressions, allowing users to choose between adding spaces, removing spaces, or preserving existing spacing.
  * Introduced a dedicated option for formatting the wx:for attribute to always remove spaces inside curly braces.

* **Style**
  * Updated template and style formatting to reflect the new bracket spacing configuration, ensuring consistent whitespace in templates and styles.

* **Documentation**
  * Added new configuration descriptions and localization entries to clarify the available bracket spacing options in the extension settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->