### PR TITLE
feat: add autoinsert space plugin for template

### DIFF
--- a/inspect-extension/components/composition/attributesCheck.mpx
+++ b/inspect-extension/components/composition/attributesCheck.mpx
@@ -6,8 +6,8 @@
       <!-- ^ 缺少必填属性 `type` -->
       <button plain="{{ true }}" />
       <swiper indicator-dots="{{ indicatorDots }}" autoplay="{{ autoplay }}"
-        interval="{{ interval }}" duration="{{ duration }}" bindtap="onSwiperChange"
-        bindtap1="onSwiperChange">
+        interval="{{ interval }}" duration="{{ duration }}"
+        bindtap="onSwiperChange" bindtap1="onSwiperChange">
         <block wx:for="{{backgroundList}}" wx:key="*this">
           <swiper-item>
             <view class="swiper-item">
@@ -17,7 +17,8 @@
         </block>
       </swiper>
       <input bind:blur="inputBlur" bindfocus="inputFocus" type="number"
-        placeholder="11" placeholder-style="color: #ccc;" maxlength="{{ 11 }}" />
+        placeholder="11" placeholder-style="color: #ccc;"
+        maxlength="{{ 11 }}" />
     </view>
   </view>
 </template>

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -15,6 +15,7 @@ import { create as createMpxSfcPlugin } from './plugins/mpx-sfc'
 import { create as createMpxTemplatePlugin } from './plugins/mpx-sfc-template'
 import { create as createMpxTemplateCompilerErrorsPlugin } from './plugins/mpx-sfc-template-compiler-errors'
 import { create as createMpxTemplateDirectiveCommentsPlugin } from './plugins/mpx-sfc-template-directive-comments'
+import { create as createMpxTemplateAutoinsertSpacePlugin } from './plugins/mpx-sfc-template-autoinsert-space'
 import { create as createMpxStyleCSSPlugin } from './plugins/mpx-sfc-style-css'
 import { create as createMpxStyleStylusPlugin } from './plugins/mpx-sfc-style-stylus'
 import { create as createMpxJsonJsonPlugin } from './plugins/mpx-sfc-json-json'
@@ -65,6 +66,7 @@ function getCommonLanguageServicePlugins(
     createMpxTemplatePlugin(),
     createMpxTemplateCompilerErrorsPlugin(),
     createMpxTemplateDirectiveCommentsPlugin(),
+    createMpxTemplateAutoinsertSpacePlugin(),
     createMpxStyleCSSPlugin(),
     createMpxStyleStylusPlugin(),
     // createMpxJsonJsPlugin(ts, getTsPluginClient),

--- a/packages/language-service/src/plugins/mpx-sfc-template-autoinsert-space.ts
+++ b/packages/language-service/src/plugins/mpx-sfc-template-autoinsert-space.ts
@@ -1,0 +1,41 @@
+import type { LanguageServicePlugin } from '@volar/language-service'
+
+export function create(): LanguageServicePlugin {
+  return {
+    name: 'mpx-sfc-template-autoinsert-space',
+
+    capabilities: {
+      autoInsertionProvider: {
+        triggerCharacters: ['}'],
+        configurationSections: ['mpx.format.template.bracketSpacing'],
+      },
+    },
+
+    create(context) {
+      return {
+        async provideAutoInsertSnippet(document, selection, change) {
+          if (document.languageId === 'html') {
+            const enabled =
+              (await context.env.getConfiguration?.<
+                'true' | 'false' | 'preserve'
+              >('mpx.format.template.bracketSpacing')) === 'true'
+            if (!enabled) {
+              return
+            }
+
+            if (
+              change.text === '{}' &&
+              document
+                .getText()
+                .slice(change.rangeOffset - 1, change.rangeOffset + 3) ===
+                '{{}}' &&
+              document.offsetAt(selection) === change.rangeOffset + 1
+            ) {
+              return ` $0 `
+            }
+          }
+        },
+      }
+    },
+  }
+}

--- a/vscode/package.nls.json
+++ b/vscode/package.nls.json
@@ -12,7 +12,7 @@
   "template.format.wrapAttributes.preserve": "保持属性的换行格式。",
   "template.format.wrapAttributes.preservealigned": "保持属性的换行格式但和第一个属性对齐。",
   "template.format.wrapLineLength.desc": "`<template>` 模块属性格式化时的最大行长度，超过此长度的属性会被换行（0 = 不换行）。",
-  "template.format.bracketSpacing.desc": "`<template>` 模板属性值花括号内的表达式前后空格的格式化方式。",
+  "template.format.bracketSpacing.desc": "`<template>` 模板属性值花括号内的表达式前后空格的格式化方式。\n\nTip: 当值为 `true`（默认）时，在 `<template>` 中输入 `{{ }}` 时会自动补全插入空格。",
   "template.format.bracketSpacing.true": "强制添加空格：\nattr=\"{{expr}}\" → attr=\"{{ expr }}\"。",
   "template.format.bracketSpacing.false": "强制移除空格：\nattr=\"{{ expr }}\" → attr=\"{{expr}}\"。",
   "template.format.bracketSpacing.preserve": "保持原有格式不变。",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an auto-insertion feature that automatically adds spaces inside curly braces (`{{ }}`) in templates when the relevant formatting option is enabled.
* **Documentation**
  * Updated the description for the bracket spacing option to clarify the new auto-insert behavior.
* **Style**
  * Improved formatting of component attributes for better readability in templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->