### PR TITLE
fix(core): enhance `parseResult.source.loc` for `wx:for` in `updateSFCTemplate`

### DIFF
--- a/packages/language-core/src/utils/transformMpxTemplate.ts
+++ b/packages/language-core/src/utils/transformMpxTemplate.ts
@@ -291,7 +291,11 @@ function tryProcessWxFor(node: ElNode, options: CompilerOptions) {
         constType: 0,
         content: contentLoc.source,
         isStatic: !isExpression,
-        loc: contentLoc,
+        loc: {
+          source: contentLoc.source,
+          start: { ...contentLoc.start },
+          end: { ...contentLoc.end },
+        },
         type: CompilerDOM.NodeTypes.SIMPLE_EXPRESSION,
       } satisfies CompilerDOM.ExpressionNode
       const children = transformMpxTemplateNodes([node], options)

--- a/packages/language-core/src/utils/transformMpxTemplate.ts
+++ b/packages/language-core/src/utils/transformMpxTemplate.ts
@@ -288,7 +288,7 @@ function tryProcessWxFor(node: ElNode, options: CompilerOptions) {
       const valueNode = createVarNode(value, 'item')
       const indexNode = createVarNode(index, 'index')
       const source = {
-        constType: 0,
+        constType: CompilerDOM.ConstantTypes.NOT_CONSTANT,
         content: contentLoc.source,
         isStatic: !isExpression,
         loc: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and accuracy when processing repeated template bindings, preventing cross-node location side effects.
  * More consistent error highlighting, selection ranges, and source-mapped positions in editors and build outputs, reducing rare inconsistencies during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->