### PR TITLE
feat: introduce prettier formatter for `<script>`

### DIFF
--- a/inspect-extension/.prettierrc.json
+++ b/inspect-extension/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true
+}

--- a/inspect-extension/.vscode/settings.json
+++ b/inspect-extension/.vscode/settings.json
@@ -6,5 +6,6 @@
   "mpx.format.template.wrapLineLength": 80,
   // stylus 格式化配置
   "mpx.format.style.stylus": {},
-  "mpx.format.template.bracketSpacing": "true"
+  "mpx.format.template.bracketSpacing": "true",
+  "mpx.format.script.prettier": true
 }

--- a/inspect-extension/components/script-json/json-js/index.mpx
+++ b/inspect-extension/components/script-json/json-js/index.mpx
@@ -29,41 +29,44 @@ defineProps<{
 </style>
 
 <script name="json">
-  const listPath = "../components/list.mpx"
-  const wxConfig: any = {
-    component: true,
-    usingComponents: {
-      list: "../components/list.mpx",
-      "list-var": listPath,
-      "list-from-dir": "../components",
-      ...__mpx_mode__ === "web" && ({
-        "list-deep-1": "../components/list1.mpx",
-        "list-deep-2": "@/script-json/components",
-        "list-deep-error": "@/script-json/component",
-      }),
-      ...__mpx_mode__ === "web" ? ({
-        "list-deep-3": "../components/list1.mpx",
-        "list-deep-4": "@/script-json/components",
-      }) : {},
-      ...({
-        "list-deep-5": "../components/list1.mpx",
-        "list-deep-6": "@/script-json/components",
-      })
-    };
-    const aliConfig = {
-      component: true,
-      usingComponents: {
-        "list": "../components/list1.mpx",
-        "list-error-path": "../components/list-error.mpx",
-        "list-alias": "@/script-json/components/list.mpx",
-        "list-from-dir": "@/script-json/components",
+const listPath = '../components/list.mpx'
+const wxConfig = {
+  component: true,
+  usingComponents: {
+    list: '../components/list.mpx',
+    'list-var': listPath,
+    'list-from-dir': '../components',
+    ...(__mpx_mode__ === 'web' && {
+      'list-deep-1': '../components/list1.mpx',
+      'list-deep-2': '@/script-json/components',
+      'list-deep-error': '@/script-json/component',
+    }),
+    ...(__mpx_mode__ === 'web'
+      ? {
+        'list-deep-3': '../components/list1.mpx',
+        'list-deep-4': '@/script-json/components',
       }
-    };
-    let finalConfig = null;
-    if(__mpx_mode__ === "ali") {
-      finalConfig = aliConfig;
-  } else {
-    finalConfig = wxConfig;
-  }
-  module.exports = finalConfig;
+      : {}),
+    ...{
+      'list-deep-5': '../components/list1.mpx',
+      'list-deep-6': '@/script-json/components',
+    },
+  },
+}
+const aliConfig = {
+  component: true,
+  usingComponents: {
+    list: '../components/list1.mpx',
+    'list-error-path': '../components/list-error.mpx',
+    'list-alias': '@/script-json/components/list.mpx',
+    'list-from-dir': '@/script-json/components',
+  },
+}
+let finalConfig = null
+if (__mpx_mode__ === 'ali') {
+  finalConfig = aliConfig
+} else {
+  finalConfig = wxConfig
+}
+module.exports = finalConfig
 </script>

--- a/inspect-extension/components/script-json/json-js/index.mpx
+++ b/inspect-extension/components/script-json/json-js/index.mpx
@@ -30,42 +30,48 @@ console.log('---> debug')
 </style>
 
 <script name="json">
-const listPath = "../components/list.mpx"
-const wxConfig = {
+const listPath = '../components/list.mpx'
+
+const wxConfigL = {
   component: true,
   usingComponents: {
-    list: "../components/list.mpx",
-    "list-var": listPath,
-    "list-from-dir": "../components",
-    ...__mpx_mode__ === "web" && ({
-      "list-deep-1": "../components/list1.mpx",
-      "list-deep-2": "@/script-json/components",
-      "list-deep-error": "@/script-json/component",
+    list: '../components/list.mpx',
+    'list-var': listPath,
+    'list-from-dir': '../components',
+    ...(__mpx_mode__ === 'web' && {
+      'list-deep-1': '../components/list1.mpx',
+      'list-deep-2': '@/script-json/components',
+      'list-deep-error': '@/script-json/component',
     }),
-    ...__mpx_mode__ === "web" ? ({
-      "list-deep-3": "../components/list1.mpx",
-      "list-deep-4": "@/script-json/components",
-    }) : {},
-    ...({
-      "list-deep-5": "../components/list1.mpx",
-      "list-deep-6": "@/script-json/components",
-    })
-  }
+    ...(__mpx_mode__ === 'web'
+      ? {
+          'list-deep-3': '../components/list1.mpx',
+          'list-deep-4': '@/script-json/components',
+        }
+      : {}),
+    ...{
+      'list-deep-5': '../components/list1.mpx',
+      'list-deep-6': '@/script-json/components',
+    },
+  },
 }
+
 const aliConfig = {
   component: true,
   usingComponents: {
-    "list": "../components/list1.mpx",
-    "list-error-path": "../components/list-error.mpx",
-    "list-alias": "@/script-json/components/list.mpx",
-    "list-from-dir": "@/script-json/components",
-  }
-};
-let finalConfig = null;
-if (__mpx_mode__ === "ali") {
-  finalConfig = aliConfig;
-} else {
-  finalConfig = wxConfig;
+    list: '../components/list1.mpx',
+    'list-error-path': '../components/list-error.mpx',
+    'list-alias': '@/script-json/components/list.mpx',
+    'list-from-dir': '@/script-json/components',
+  },
 }
-module.exports = finalConfig;
+
+let finalConfig = null
+if (__mpx_mode__ === 'ali') {
+  finalConfig = aliConfig
+} else {
+  finalConfig = wxConfig
+}
+
+module.exports = finalConfig
 </script>

--- a/inspect-extension/components/script-json/json-js/index.mpx
+++ b/inspect-extension/components/script-json/json-js/index.mpx
@@ -21,6 +21,7 @@ defineProps<{
   msg: string
   count?: number
 }>()
+console.log('---> debug')
 </script>
 
 <style lang="stylus">
@@ -29,44 +30,42 @@ defineProps<{
 </style>
 
 <script name="json">
-const listPath = '../components/list.mpx'
+const listPath = "../components/list.mpx"
 const wxConfig = {
   component: true,
   usingComponents: {
-    list: '../components/list.mpx',
-    'list-var': listPath,
-    'list-from-dir': '../components',
-    ...(__mpx_mode__ === 'web' && {
-      'list-deep-1': '../components/list1.mpx',
-      'list-deep-2': '@/script-json/components',
-      'list-deep-error': '@/script-json/component',
+    list: "../components/list.mpx",
+    "list-var": listPath,
+    "list-from-dir": "../components",
+    ...__mpx_mode__ === "web" && ({
+      "list-deep-1": "../components/list1.mpx",
+      "list-deep-2": "@/script-json/components",
+      "list-deep-error": "@/script-json/component",
     }),
-    ...(__mpx_mode__ === 'web'
-      ? {
-        'list-deep-3': '../components/list1.mpx',
-        'list-deep-4': '@/script-json/components',
-      }
-      : {}),
-    ...{
-      'list-deep-5': '../components/list1.mpx',
-      'list-deep-6': '@/script-json/components',
-    },
-  },
+    ...__mpx_mode__ === "web" ? ({
+      "list-deep-3": "../components/list1.mpx",
+      "list-deep-4": "@/script-json/components",
+    }) : {},
+    ...({
+      "list-deep-5": "../components/list1.mpx",
+      "list-deep-6": "@/script-json/components",
+    })
+  }
 }
 const aliConfig = {
   component: true,
   usingComponents: {
-    list: '../components/list1.mpx',
-    'list-error-path': '../components/list-error.mpx',
-    'list-alias': '@/script-json/components/list.mpx',
-    'list-from-dir': '@/script-json/components',
-  },
-}
-let finalConfig = null
-if (__mpx_mode__ === 'ali') {
-  finalConfig = aliConfig
+    "list": "../components/list1.mpx",
+    "list-error-path": "../components/list-error.mpx",
+    "list-alias": "@/script-json/components/list.mpx",
+    "list-from-dir": "@/script-json/components",
+  }
+};
+let finalConfig = null;
+if (__mpx_mode__ === "ali") {
+  finalConfig = aliConfig;
 } else {
-  finalConfig = wxConfig
+  finalConfig = wxConfig;
 }
-module.exports = finalConfig
+module.exports = finalConfig;
 </script>

--- a/packages/language-core/src/utils/parseJsonUsingComponents.ts
+++ b/packages/language-core/src/utils/parseJsonUsingComponents.ts
@@ -141,7 +141,7 @@ export function parseUsingComponentsWithJs(
   function handleSpreadAssignment(spreadProp: ts.SpreadAssignment) {
     let expression = spreadProp.expression
 
-    // 处理条件表达式 __mpx_mode__ === "web" && ({ ... })
+    // 处理条件表达式 __mpx_mode__ === 'web' && ({ ... })
     if (
       ts.isBinaryExpression(expression) &&
       expression.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
@@ -150,7 +150,7 @@ export function parseUsingComponentsWithJs(
       expression = expression.right
     }
 
-    // 处理三目运算符 __mpx_mode__ === "web" ? ({ ... }) : ({ ... })
+    // 处理三目运算符 __mpx_mode__ === 'web' ? ({ ... }) : ({ ... })
     if (ts.isConditionalExpression(expression)) {
       parseObjectFromExpression(expression.whenTrue)
       parseObjectFromExpression(expression.whenFalse)
@@ -165,6 +165,22 @@ export function parseUsingComponentsWithJs(
     // 处理括号包裹的表达式 ({ ... })
     if (ts.isParenthesizedExpression(expression)) {
       expression = expression.expression
+    }
+
+    // 处理形如 (__mpx_mode__ === 'web' && { ... }) 的逻辑与表达式
+    if (
+      ts.isBinaryExpression(expression) &&
+      expression.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
+    ) {
+      // 只关心右侧对象部分
+      return parseObjectFromExpression(expression.right)
+    }
+
+    // 处理形如 (__mpx_mode__ === 'web' ? { ... } : { ... }) 的三元表达式
+    if (ts.isConditionalExpression(expression)) {
+      parseObjectFromExpression(expression.whenTrue)
+      parseObjectFromExpression(expression.whenFalse)
+      return
     }
 
     // 如果是对象字面量，解析其中的属性

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -31,6 +31,7 @@
     "volar-service-emmet": "0.0.63",
     "volar-service-html": "0.0.64",
     "volar-service-json": "0.0.64",
+    "volar-service-prettier": "0.0.64",
     "volar-service-typescript": "0.0.64",
     "vscode-css-languageservice": "^6.3.6",
     "vscode-html-languageservice": "^5.5.0",

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -13,13 +13,14 @@ import { create as createTypeScriptDocCommentTemplatePlugin } from 'volar-servic
 import { create as creatempxDocumentHighlightsPlugin } from './plugins/mpx-document-highlights'
 import { create as createMpxSfcPlugin } from './plugins/mpx-sfc'
 import { create as createMpxTemplatePlugin } from './plugins/mpx-sfc-template'
+import { create as createMpxTemplateAutoinsertSpacePlugin } from './plugins/mpx-sfc-template-autoinsert-space'
 import { create as createMpxTemplateCompilerErrorsPlugin } from './plugins/mpx-sfc-template-compiler-errors'
 import { create as createMpxTemplateDirectiveCommentsPlugin } from './plugins/mpx-sfc-template-directive-comments'
-import { create as createMpxTemplateAutoinsertSpacePlugin } from './plugins/mpx-sfc-template-autoinsert-space'
+import { create as createMpxTemplateLinksPlugin } from './plugins/mpx-sfc-template-links'
+import { create as createMpxScriptPrettierPlugin } from './plugins/mpx-sfc-script-prettier'
 import { create as createMpxStyleCSSPlugin } from './plugins/mpx-sfc-style-css'
 import { create as createMpxStyleStylusPlugin } from './plugins/mpx-sfc-style-stylus'
 import { create as createMpxJsonJsonPlugin } from './plugins/mpx-sfc-json-json'
-import { create as createMpxTemplateLinksPlugin } from './plugins/mpx-sfc-template-links'
 import { create as createMpxJsonLinksPlugin } from './plugins/mpx-sfc-json-links'
 import { Commands } from './types'
 
@@ -39,6 +40,7 @@ export function createMpxLanguageServicePlugins(
     | undefined,
 ) {
   const plugins = [
+    // TODO 根据选项禁用 script 部分格式化
     createTypeScriptSyntacticPlugin(ts),
     createTypeScriptDocCommentTemplatePlugin(ts),
     ...getCommonLanguageServicePlugins(ts, () => tsPluginClient),
@@ -67,6 +69,7 @@ function getCommonLanguageServicePlugins(
     createMpxTemplateCompilerErrorsPlugin(),
     createMpxTemplateDirectiveCommentsPlugin(),
     createMpxTemplateAutoinsertSpacePlugin(),
+    createMpxScriptPrettierPlugin(),
     createMpxStyleCSSPlugin(),
     createMpxStyleStylusPlugin(),
     // createMpxJsonJsPlugin(ts, getTsPluginClient),

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -8,8 +8,8 @@ import type {
 } from '@volar/language-service'
 import { parse } from '@mpxjs/language-core'
 import { create as createEmmetPlugin } from 'volar-service-emmet'
-import { create as createTypeScriptSyntacticPlugin } from 'volar-service-typescript/lib/plugins/syntactic'
 import { create as createTypeScriptDocCommentTemplatePlugin } from 'volar-service-typescript/lib/plugins/docCommentTemplate'
+import { create as createTypeScriptSyntacticPlugin } from './plugins/typescript-syntactic'
 import { create as creatempxDocumentHighlightsPlugin } from './plugins/mpx-document-highlights'
 import { create as createMpxSfcPlugin } from './plugins/mpx-sfc'
 import { create as createMpxTemplatePlugin } from './plugins/mpx-sfc-template'
@@ -39,12 +39,8 @@ export function createMpxLanguageServicePlugins(
       })
     | undefined,
 ) {
-  const plugins = [
-    // TODO 根据选项禁用 script 部分格式化
-    createTypeScriptSyntacticPlugin(ts),
-    createTypeScriptDocCommentTemplatePlugin(ts),
-    ...getCommonLanguageServicePlugins(ts, () => tsPluginClient),
-  ]
+  const plugins = getCommonLanguageServicePlugins(ts, () => tsPluginClient)
+
   if (tsPluginClient) {
     plugins.push(
       creatempxDocumentHighlightsPlugin(tsPluginClient.getDocumentHighlights),
@@ -54,16 +50,19 @@ export function createMpxLanguageServicePlugins(
     // avoid affecting TS plugin
     delete plugin.capabilities.semanticTokensProvider
   }
+
   return plugins
 }
 
 function getCommonLanguageServicePlugins(
-  _ts: typeof import('typescript'),
+  ts: typeof import('typescript'),
   _getTsPluginClient: (
     context: LanguageServiceContext,
   ) => IRequests | undefined,
 ): LanguageServicePlugin[] {
   return [
+    createTypeScriptSyntacticPlugin(ts),
+    createTypeScriptDocCommentTemplatePlugin(ts),
     createMpxSfcPlugin(),
     createMpxTemplatePlugin(),
     createMpxTemplateCompilerErrorsPlugin(),

--- a/packages/language-service/src/plugins/mpx-sfc-script-prettier.ts
+++ b/packages/language-service/src/plugins/mpx-sfc-script-prettier.ts
@@ -1,0 +1,83 @@
+import type { LanguageServicePlugin } from '@volar/language-service'
+import { URI } from 'vscode-uri'
+import { create as baseCreate } from 'volar-service-prettier'
+
+export function create(): LanguageServicePlugin {
+  // TODO prettierInstanceOrGetter resolve prettier
+  const base = baseCreate(() => import('prettier'), {
+    documentSelector: ['typescript', 'javascript'],
+    isFormattingEnabled: async (prettier, document, context) => {
+      const parsed = URI.parse(document.uri)
+      const uri = context.decodeEmbeddedDocumentUri(parsed)?.[0] ?? parsed
+      if (uri.scheme === 'file') {
+        const fileInfo = await prettier.getFileInfo(uri.fsPath, {
+          ignorePath: '.prettierignore',
+          resolveConfig: false,
+        })
+        if (fileInfo.ignored) {
+          return false
+        }
+      }
+      return true
+    },
+  })
+
+  return {
+    name: 'mpx-script-prettier',
+
+    capabilities: base.capabilities,
+
+    create(context) {
+      if (!context.project.mpx) {
+        return {}
+      }
+
+      const baseInstance = base.create(context)
+
+      // TODO 新增 prettier 格式化开启选项
+      return {
+        ...baseInstance,
+
+        async provideDocumentFormattingEdits(
+          document,
+          range,
+          options,
+          embeddedCodeContext,
+          token,
+        ) {
+          if (
+            document.languageId !== 'typescript' &&
+            document.languageId !== 'javascript'
+          ) {
+            return
+          }
+
+          const uri = URI.parse(document.uri)
+          const decoded = context.decodeEmbeddedDocumentUri(uri)
+          if (!decoded) {
+            return
+          }
+          const [, embeddedCodeId] = decoded
+          if (!/script(setup)?_raw/.test(embeddedCodeId)) {
+            return
+          }
+
+          const res = await baseInstance.provideDocumentFormattingEdits?.(
+            document,
+            range,
+            options,
+            embeddedCodeContext,
+            token,
+          )
+
+          // TODO 根据 'mpx.format.script.initialIndent' 整体缩进
+          if (res?.[0]?.newText) {
+            res[0].newText = '\n' + res[0].newText
+          }
+
+          return res
+        },
+      }
+    },
+  }
+}

--- a/packages/language-service/src/plugins/mpx-sfc-script-prettier.ts
+++ b/packages/language-service/src/plugins/mpx-sfc-script-prettier.ts
@@ -68,7 +68,7 @@ export function create(): LanguageServicePlugin {
         tabWidth: formatOptions.tabSize,
         useTabs: !formatOptions.insertSpaces,
         ...editorOptions,
-        ...configOptions,
+        ...(configOptions ?? {}),
         parser: 'typescript',
       }
       const tabWidth = res.tabWidth ?? 2
@@ -99,7 +99,7 @@ export function create(): LanguageServicePlugin {
           embeddedCodeContext,
           token,
         ) {
-          if (!prettierEnabled(document, context)) {
+          if (!(await prettierEnabled(document, context))) {
             return
           }
 

--- a/packages/language-service/src/plugins/mpx-sfc-script-prettier.ts
+++ b/packages/language-service/src/plugins/mpx-sfc-script-prettier.ts
@@ -7,6 +7,13 @@ export function create(): LanguageServicePlugin {
   const base = baseCreate(() => import('prettier'), {
     documentSelector: ['typescript', 'javascript'],
     isFormattingEnabled: async (prettier, document, context) => {
+      const enablePrettier =
+        (await context.env.getConfiguration?.('mpx.format.script.prettier')) ??
+        false
+      if (!enablePrettier) {
+        // 默认关闭 prettier 格式化
+        return false
+      }
       const parsed = URI.parse(document.uri)
       const uri = context.decodeEmbeddedDocumentUri(parsed)?.[0] ?? parsed
       if (uri.scheme === 'file') {
@@ -19,6 +26,29 @@ export function create(): LanguageServicePlugin {
         }
       }
       return true
+    },
+    getFormattingOptions: async (
+      prettier,
+      document,
+      formatOptions,
+      context,
+    ) => {
+      const parsed = URI.parse(document.uri)
+      const uri = context.decodeEmbeddedDocumentUri(parsed)?.[0] ?? parsed
+      const configOptions =
+        uri.scheme === 'file'
+          ? await prettier.resolveConfig(uri.fsPath, { useCache: false })
+          : null
+      const editorOptions: Record<string, any> =
+        (await context.env.getConfiguration?.('prettier', uri.toString())) ?? {}
+      return {
+        filepath: uri.scheme === 'file' ? uri.fsPath : undefined,
+        tabWidth: formatOptions.tabSize,
+        useTabs: !formatOptions.insertSpaces,
+        ...editorOptions,
+        ...configOptions,
+        parser: 'typescript',
+      }
     },
   })
 
@@ -34,7 +64,6 @@ export function create(): LanguageServicePlugin {
 
       const baseInstance = base.create(context)
 
-      // TODO 新增 prettier 格式化开启选项
       return {
         ...baseInstance,
 
@@ -58,6 +87,7 @@ export function create(): LanguageServicePlugin {
             return
           }
           const [, embeddedCodeId] = decoded
+          // 暂时仅针对 script 部分允许 prettier 格式化（json-js 部分是否需要可以看后续用户反馈）
           if (!/script(setup)?_raw/.test(embeddedCodeId)) {
             return
           }

--- a/packages/language-service/src/plugins/mpx-sfc.ts
+++ b/packages/language-service/src/plugins/mpx-sfc.ts
@@ -93,6 +93,17 @@ export function create(): LanguageServicePlugin {
               ) {
                 options.initialIndentLevel++
               }
+            } else if (virtualCode.id === 'json_js') {
+              if (
+                (await context.env.getConfiguration?.(
+                  'mpx.format.script.initialIndent',
+                )) ??
+                false
+              ) {
+                options.initialIndentLevel = 1
+              } else {
+                options.initialIndentLevel = 0
+              }
             } else if (virtualCode.id.startsWith('style_')) {
               if (
                 (await context.env.getConfiguration?.(

--- a/packages/language-service/src/plugins/typescript-syntactic.ts
+++ b/packages/language-service/src/plugins/typescript-syntactic.ts
@@ -1,0 +1,19 @@
+import type { LanguageServicePlugin } from '@volar/language-service'
+import { create as baseCreate } from 'volar-service-typescript/lib/plugins/syntactic'
+
+export function create(ts: typeof import('typescript')): LanguageServicePlugin {
+  const base = baseCreate(ts, {
+    isFormattingEnabled: async (_, context) => {
+      const enablePrettier =
+        (await context.env.getConfiguration?.('mpx.format.script.prettier')) ??
+        false
+      if (enablePrettier) {
+        // 开启 script.prettier 后关闭 ts 默认格式化
+        return false
+      }
+      return true
+    },
+  })
+
+  return base
+}

--- a/packages/language-service/src/plugins/typescript-syntactic.ts
+++ b/packages/language-service/src/plugins/typescript-syntactic.ts
@@ -1,13 +1,11 @@
 import type { LanguageServicePlugin } from '@volar/language-service'
 import { create as baseCreate } from 'volar-service-typescript/lib/plugins/syntactic'
+import { prettierEnabled } from '../utils/prettier'
 
 export function create(ts: typeof import('typescript')): LanguageServicePlugin {
   const base = baseCreate(ts, {
-    isFormattingEnabled: async (_, context) => {
-      const enablePrettier =
-        (await context.env.getConfiguration?.('mpx.format.script.prettier')) ??
-        false
-      if (enablePrettier) {
+    isFormattingEnabled: async (document, context) => {
+      if (await prettierEnabled(document, context)) {
         // 开启 script.prettier 后关闭 ts 默认格式化
         return false
       }

--- a/packages/language-service/src/utils/prettier.ts
+++ b/packages/language-service/src/utils/prettier.ts
@@ -1,0 +1,38 @@
+import type { TextDocument } from 'vscode-languageserver-textdocument'
+import type { LanguageServiceContext } from '@volar/language-service'
+import { URI } from 'vscode-uri'
+
+export async function prettierEnabled(
+  document: TextDocument,
+  context: LanguageServiceContext,
+): Promise<boolean> {
+  if (
+    document.languageId !== 'typescript' &&
+    document.languageId !== 'javascript'
+  ) {
+    return false
+  }
+
+  const uri = URI.parse(document.uri)
+  const decoded = context.decodeEmbeddedDocumentUri(uri)
+  if (!decoded) {
+    return false
+  }
+
+  const [_, embeddedCodeId] = decoded
+
+  if (
+    embeddedCodeId === 'script_raw' ||
+    embeddedCodeId === 'scriptsetup_raw' ||
+    embeddedCodeId === 'json_js'
+  ) {
+    // script_js/ts json_js 部分允许 prettier 格式化
+    const enablePrettierConfig: boolean =
+      (await context.env.getConfiguration?.('mpx.format.script.prettier')) ??
+      false
+
+    return enablePrettierConfig
+  }
+
+  return false
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       volar-service-json:
         specifier: 0.0.64
         version: 0.0.64(@volar/language-service@2.4.12)
+      volar-service-prettier:
+        specifier: 0.0.64
+        version: 0.0.64(@volar/language-service@2.4.12)(prettier@3.5.3)
       volar-service-typescript:
         specifier: 0.0.64
         version: 0.0.64(@volar/language-service@2.4.12)
@@ -4059,6 +4062,17 @@ packages:
       '@volar/language-service': ~2.4.0
     peerDependenciesMeta:
       '@volar/language-service':
+        optional: true
+
+  volar-service-prettier@0.0.64:
+    resolution: {integrity: sha512-Wq8XGHLYDC+jy2GGUTfcK5MGyPUr2afCIWGPgzQ7uRR12melAoeHoH1Bc1YSx870paqQIUU/8EkoiW0oSxXEkg==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+      prettier: ^2.2 || ^3.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+      prettier:
         optional: true
 
   volar-service-typescript@0.0.64:
@@ -8395,6 +8409,13 @@ snapshots:
       vscode-uri: 3.1.0
     optionalDependencies:
       '@volar/language-service': 2.4.12
+
+  volar-service-prettier@0.0.64(@volar/language-service@2.4.12)(prettier@3.5.3):
+    dependencies:
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.12
+      prettier: 3.5.3
 
   volar-service-typescript@0.0.64(@volar/language-service@2.4.12):
     dependencies:

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -251,10 +251,15 @@
           ],
           "markdownDescription": "%template.format.bracketSpacing.desc%"
         },
+        "mpx.format.script.prettier": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "%template.format.script.prettier%"
+        },
         "mpx.format.style.stylus": {
           "type": "object",
           "default": {},
-          "markdownDescription": "%style.stylus.format.desc%"
+          "markdownDescription": "%template.format.style.stylus.format.desc%"
         }
       }
     },

--- a/vscode/package.nls.json
+++ b/vscode/package.nls.json
@@ -16,5 +16,6 @@
   "template.format.bracketSpacing.true": "强制添加空格：\nattr=\"{{expr}}\" → attr=\"{{ expr }}\"。",
   "template.format.bracketSpacing.false": "强制移除空格：\nattr=\"{{ expr }}\" → attr=\"{{expr}}\"。",
   "template.format.bracketSpacing.preserve": "保持原有格式不变。",
-  "style.stylus.format.desc": "`<style lang=\"stylus\">` 模块代码格式化配置，配置选项请参考 Stylus Supremacy 的[格式化选项](https://thisismanta.github.io/stylus-supremacy/#options)。\n\n_比如：_\n```\n\"mpx.format.style.stylus\": {\n  \"insertColons\": true,\n  \"insertSemicolons\": true\n}\n```"
+  "template.format.style.stylus.format.desc": "`<style lang=\"stylus\">` 模块代码格式化配置，配置选项请参考 Stylus Supremacy 的[格式化选项](https://thisismanta.github.io/stylus-supremacy/#options)。\n\n_比如：_\n```\n\"mpx.format.style.stylus\": {\n  \"insertColons\": true,\n  \"insertSemicolons\": true\n}\n```",
+  "template.format.script.prettier": "`<script>` 模块使用 Prettier 格式化（取代默认使用的内置 JS/TS 格式化）\n\nTip: 项目依赖中需安装 Prettier。"
 }

--- a/vscode/package.nls.json
+++ b/vscode/package.nls.json
@@ -2,7 +2,7 @@
   "splitEditors.icon.desc": "在编辑器标题区域显示试图拆分图标。",
   "template.format.template.initialIndent": "`<template>` 模块内容向后缩进。",
   "template.format.style.initialIndent": "`<style>` 模块内容向后缩进。",
-  "template.format.script.initialIndent": "`<script>` 模块内容向后缩进。",
+  "template.format.script.initialIndent": "`<script>` 模块（包括 `<script name=\"json\">` 模块）内容向后缩进。",
   "template.format.wrapAttributes.desc": "`<template>` 属性换行方式。",
   "template.format.wrapAttributes.auto": "仅在超出行长度时换行属性。",
   "template.format.wrapAttributes.force": "除第一个属性外，每个属性都换行。",
@@ -17,5 +17,5 @@
   "template.format.bracketSpacing.false": "强制移除空格：\nattr=\"{{ expr }}\" → attr=\"{{expr}}\"。",
   "template.format.bracketSpacing.preserve": "保持原有格式不变。",
   "template.format.style.stylus.format.desc": "`<style lang=\"stylus\">` 模块代码格式化配置，配置选项请参考 Stylus Supremacy 的[格式化选项](https://thisismanta.github.io/stylus-supremacy/#options)。\n\n_比如：_\n```\n\"mpx.format.style.stylus\": {\n  \"insertColons\": true,\n  \"insertSemicolons\": true\n}\n```",
-  "template.format.script.prettier": "`<script>` 模块使用 Prettier 格式化（取代默认使用的内置 JS/TS 格式化）\n\nTip: 项目依赖中需安装 Prettier。"
+  "template.format.script.prettier": "`<script>` 模块（包括 `<script name=\"json\">` 模块）使用 Prettier 格式化（取代默认内置的 JS/TS 格式化）。\n\nTip: 项目依赖中需安装 Prettier。"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional Prettier-based formatting for <script> blocks (including <script name="json">) with workspace-aware resolution and initial-indent support for JSON script blocks.
  - New syntax plugin that defers TS formatting to Prettier when enabled.

- Improvements
  - More robust extraction of components from conditional/spread patterns for better IntelliSense.
  - Added template auto-insert space and JSON/template link features.

- Documentation
  - New setting, localized strings, and updated descriptions for Prettier and indent behavior.

- Chores
  - Added Prettier config, VS Code defaults, and a Prettier service dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->