### PR TITLE
feat: 支持mpx文件css样式颜色调色板显示和更改颜色

### DIFF
--- a/inspect-extension/components/script-json/components/list.mpx
+++ b/inspect-extension/components/script-json/components/list.mpx
@@ -1,6 +1,10 @@
 <template>
   <view class="list">
-    <view wx:for="{{listData}}" wx:key="*this">{{item}}</view>
+    <view
+      wx:for="{{ listData }}"
+      wx:key="*this"
+      >{{ item }}</view
+    >
   </view>
 </template>
 
@@ -9,17 +13,18 @@ import { createComponent } from '@mpxjs/core'
 
 createComponent({
   data: {
-    listData: ['手机', '电视', '电脑']
-  }
+    listData: ['手机', '电视', '电脑'],
+  },
 })
 </script>
 
 <style lang="stylus">
-  #fff 
-    background #aaa
-  #bbb #ccc
-    border 1px solid #683434
-    background  #333
+#fff
+  background #aaa
+
+#bbb #ccc
+  border 1px solid #683434
+  background #333
 </style>
 
 <script type="application/json">

--- a/inspect-extension/components/script-json/components/list.mpx
+++ b/inspect-extension/components/script-json/components/list.mpx
@@ -15,8 +15,11 @@ createComponent({
 </script>
 
 <style lang="stylus">
-  .list
-    background-color #ccc
+  #fff 
+    background #aaa
+  #bbb #ccc
+    border 1px solid #683434
+    background  #333
 </style>
 
 <script type="application/json">

--- a/inspect-extension/components/script-json/components/list.mpx
+++ b/inspect-extension/components/script-json/components/list.mpx
@@ -16,7 +16,7 @@ createComponent({
 
 <style lang="stylus">
   .list
-    background-color red
+    background-color #ccc
 </style>
 
 <script type="application/json">

--- a/inspect-extension/components/script-json/components/list1.mpx
+++ b/inspect-extension/components/script-json/components/list1.mpx
@@ -1,6 +1,10 @@
 <template>
   <view class="list">
-    <view wx:for="{{listData}}" wx:key="*this">{{item}}</view>
+    <view
+      wx:for="{{ listData }}"
+      wx:key="*this"
+      >{{ item }}</view
+    >
   </view>
 </template>
 
@@ -9,8 +13,8 @@ import { createComponent } from '@mpxjs/core'
 
 createComponent({
   data: {
-    listData: ['手机', '电视', '电脑']
-  }
+    listData: ['手机', '电视', '电脑'],
+  },
 })
 </script>
 

--- a/inspect-extension/components/script-json/components/list1.mpx
+++ b/inspect-extension/components/script-json/components/list1.mpx
@@ -14,9 +14,10 @@ createComponent({
 })
 </script>
 
-<style lang="stylus">
-  .list
-    background-color red
+<style lang="scss">
+.list {
+  background-color: #ddcaca;
+}
 </style>
 
 <script type="application/json">

--- a/inspect-extension/components/stylus/basic01.mpx
+++ b/inspect-extension/components/stylus/basic01.mpx
@@ -3,18 +3,21 @@
 .list {
   display: flex;
   background-color: #f0f0f0;
+  color: red;
 }
 </style>
 <style lang="scss">
 .list {
   display: flex;
   background-color: #f0f0f0;
+  color: red;
 }
 </style>
 <style lang="less">
 .list {
   display: flex;
   background-color: #f0f0f0;
+  color: red;
 }
 </style>
 <!-- postcss 我们视作 SCSS 对等处理，高亮交给官方插件 -->
@@ -22,6 +25,7 @@
 .list {
   display: flex;
   background-color: #f0f0f0;
+  color: red;
 }
 </style>
 
@@ -30,13 +34,15 @@
 .list
   display: flex
   background-color: #f0f0f0;
+  color: red;
 </style>
 
 <!-- 内置 CSS 插件不支持 Stylus，由我们自行实现插件来支持
  1. 高亮: 交给官方插件
  2. formater: Stylus Supremacy
  3. 补全: 自行实现
- 3. TODO: Linter
+ 4. 颜色板
+ 5. TODO: Linter
   -->
 <style lang="stylus">
 @import './main.styl'
@@ -45,4 +51,20 @@
   // 注释
   display flex // 注释
   background-color #f0f0f0
+  color #ecc721
+  color red
+
+  #fff
+    background #1673d7
+
+  #bbb #ccc
+    border 1px solid #c72121
+    background #a9ea4f
+
+#fff
+  background #2efdd0
+
+#bbb #ccc
+  border 1px solid #402deb
+  background #e217e5
 </style>

--- a/inspect-extension/components/stylus/basic01.mpx
+++ b/inspect-extension/components/stylus/basic01.mpx
@@ -51,11 +51,12 @@
   // 注释
   display flex // 注释
   background-color #f0f0f0
-  color #ecc721
+  color: #ecc721;
   color red
 
   #fff
     background #1673d7
+    background#1673d7
 
   #bbb #ccc
     border 1px solid #c72121

--- a/packages/language-service/src/plugins/mpx-sfc-style-css.ts
+++ b/packages/language-service/src/plugins/mpx-sfc-style-css.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'vscode-css-languageservice'
+import type * as CSS from 'vscode-css-languageservice'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
 import type {
   LanguageServicePlugin,

--- a/packages/language-service/src/plugins/mpx-sfc-style-stylus.ts
+++ b/packages/language-service/src/plugins/mpx-sfc-style-stylus.ts
@@ -1,4 +1,5 @@
 import type * as vscode from 'vscode-languageserver-protocol'
+import type { TextDocument } from 'vscode-languageserver-textdocument'
 import type { LanguageServicePlugin } from '@volar/language-service'
 import * as stylusSupremacy from 'stylus-supremacy'
 import * as CSS from 'vscode-css-languageservice'
@@ -10,6 +11,11 @@ import {
   getValues,
   isValue,
 } from '../utils/stylus'
+
+// Examples matched: "color #fff", "color: #fff;", "color:#fff", "    background #aaa"
+// Examples not matched: "#fff" at line start, "#id", selectors like "a #abc", "#bbb #ccc" (second #)
+const stylusColorRegex =
+  /(?<!^)(?<!^\s*)(?<!#[0-9a-fA-F]{0,6}\s)(?<=:| )#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})(?![0-9a-fA-F])/gm
 
 export function create(): LanguageServicePlugin {
   const cssBuiltinData = CSS.getDefaultCSSDataProvider()
@@ -143,7 +149,80 @@ export function create(): LanguageServicePlugin {
             return
           }
         },
+
+        /**
+         * support colorDecorators and colorPresentation
+         */
+        provideDocumentColors(document: TextDocument) {
+          if (document.languageId !== 'stylus') {
+            return
+          }
+
+          return parseStylusColors(document)
+        },
+
+        provideColorPresentations(document, color, range) {
+          if (document.languageId !== 'stylus') {
+            return
+          }
+
+          return parseStylusColorPresentation(range, color)
+        },
       }
     },
   }
+}
+
+function parseStylusColors(document: TextDocument): CSS.ColorInformation[] {
+  const colors: CSS.ColorInformation[] = []
+  const text = document.getText()
+  let match: RegExpExecArray | null
+  while ((match = stylusColorRegex.exec(text))) {
+    const start = document.positionAt(match.index)
+    const end = document.positionAt(match.index + match[0].length)
+    const hex = match[1]
+    let r = 0,
+      g = 0,
+      b = 0
+    if (hex.length === 3) {
+      r = parseInt(hex[0] + hex[0], 16)
+      g = parseInt(hex[1] + hex[1], 16)
+      b = parseInt(hex[2] + hex[2], 16)
+    } else {
+      r = parseInt(hex.slice(0, 2), 16)
+      g = parseInt(hex.slice(2, 4), 16)
+      b = parseInt(hex.slice(4, 6), 16)
+    }
+    colors.push({
+      range: { start, end },
+      color: {
+        red: r / 255,
+        green: g / 255,
+        blue: b / 255,
+        alpha: 1,
+      },
+    })
+  }
+  return colors
+}
+
+function parseStylusColorPresentation(
+  range: CSS.Range,
+  color: CSS.Color,
+): CSS.ColorPresentation[] {
+  const colors: CSS.ColorPresentation[] = []
+  const r = Math.round(color.red * 255)
+  const g = Math.round(color.green * 255)
+  const b = Math.round(color.blue * 255)
+  const hex = `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
+
+  colors.push({
+    label: hex,
+    textEdit: {
+      range,
+      newText: hex,
+    },
+  })
+
+  return colors
 }

--- a/packages/language-service/src/plugins/mpx-sfc-style-stylus.ts
+++ b/packages/language-service/src/plugins/mpx-sfc-style-stylus.ts
@@ -157,7 +157,6 @@ export function create(): LanguageServicePlugin {
           if (document.languageId !== 'stylus') {
             return
           }
-
           return parseStylusColors(document)
         },
 
@@ -165,7 +164,6 @@ export function create(): LanguageServicePlugin {
           if (document.languageId !== 'stylus') {
             return
           }
-
           return parseStylusColorPresentation(range, color)
         },
       }
@@ -215,7 +213,6 @@ function parseStylusColorPresentation(
   const g = Math.round(color.green * 255)
   const b = Math.round(color.blue * 255)
   const hex = `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
-
   colors.push({
     label: hex,
     textEdit: {
@@ -223,6 +220,5 @@ function parseStylusColorPresentation(
       newText: hex,
     },
   })
-
   return colors
 }

--- a/packages/language-service/src/plugins/mpx-sfc-style-stylus.ts
+++ b/packages/language-service/src/plugins/mpx-sfc-style-stylus.ts
@@ -176,43 +176,51 @@ function parseStylusColors(document: TextDocument): CSS.ColorInformation[] {
   const colors: CSS.ColorInformation[] = []
   const text = document.getText()
   let match: RegExpExecArray | null
-  while ((match = stylusColorRegex.exec(text))) {
-    const fullMatch = match[0]
-    const valueWithColor = match[3] // The part containing the hex color
-    const hex = match[4] // The captured hex digits
 
-    // Find the position of the # in the value part
-    const colorIndex = valueWithColor.indexOf('#')
-    if (colorIndex === -1) continue
+  try {
+    while ((match = stylusColorRegex.exec(text))) {
+      const fullMatch = match[0]
+      const valueWithColor = match[3] // The part containing the hex color
+      const hex = match[4] // The captured hex digits
 
-    // Calculate the absolute position in the document
-    const lineStartIndex = match.index
-    const colorStartIndex =
-      lineStartIndex + fullMatch.indexOf(valueWithColor) + colorIndex
-    const colorEndIndex = colorStartIndex + 1 + hex.length // +1 for the #
-    const start = document.positionAt(colorStartIndex)
-    const end = document.positionAt(colorEndIndex)
-    let [r, g, b] = [0, 0, 0]
+      // Find the position of the # in the value part
+      const colorIndex = valueWithColor.indexOf('#')
+      if (colorIndex === -1) continue
 
-    if (hex.length === 3) {
-      r = parseInt(hex[0] + hex[0], 16)
-      g = parseInt(hex[1] + hex[1], 16)
-      b = parseInt(hex[2] + hex[2], 16)
-    } else {
-      r = parseInt(hex.slice(0, 2), 16)
-      g = parseInt(hex.slice(2, 4), 16)
-      b = parseInt(hex.slice(4, 6), 16)
+      // Calculate the absolute position in the document
+      const lineStartIndex = match.index
+      const colorStartIndex =
+        lineStartIndex + fullMatch.indexOf(valueWithColor) + colorIndex
+      const colorEndIndex = colorStartIndex + 1 + hex.length // +1 for the #
+      const start = document.positionAt(colorStartIndex)
+      const end = document.positionAt(colorEndIndex)
+      let [r, g, b] = [0, 0, 0]
+
+      if (hex.length === 3) {
+        r = parseInt(hex[0] + hex[0], 16)
+        g = parseInt(hex[1] + hex[1], 16)
+        b = parseInt(hex[2] + hex[2], 16)
+      } else {
+        r = parseInt(hex.slice(0, 2), 16)
+        g = parseInt(hex.slice(2, 4), 16)
+        b = parseInt(hex.slice(4, 6), 16)
+      }
+      colors.push({
+        range: { start, end },
+        color: {
+          red: r / 255,
+          green: g / 255,
+          blue: b / 255,
+          alpha: 1,
+        },
+      })
     }
-    colors.push({
-      range: { start, end },
-      color: {
-        red: r / 255,
-        green: g / 255,
-        blue: b / 255,
-        alpha: 1,
-      },
-    })
+  } catch (error) {
+    console.error(
+      `[Mpx] Stylus Color Parsing Error: ${error instanceof Error ? error.message : String(error)}`,
+    )
   }
+
   return colors
 }
 


### PR DESCRIPTION
由于mpx文件语言服务走的是mpx language service，调色板没有支持，因此处理一下stylus和正常的解析
目前vsc是内置支持css\scss\less的，所以新增解析stylus的方法，其他走内置方法
@wangshunnn 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added in-editor color highlighting and quick-edit support for Stylus styles (color swatches and hex replacements).

- Style
  - Reformatted list templates to multi-line structure for improved readability without changing behavior.
  - Updated sample component styling and expanded color palettes across CSS/SCSS/Less/PostCSS/Sass/Stylus examples.
  - Minor script punctuation/formatting tweaks with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->