### PR TITLE
fix: template view break-wrap

### DIFF
--- a/packages/language-service/src/plugins/mpx-prettier.ts
+++ b/packages/language-service/src/plugins/mpx-prettier.ts
@@ -31,6 +31,9 @@ export function create(): LanguageServicePlugin {
   }
 
   const base = baseCreate(prettierInstanceOrGetter, {
+    html: {
+      breakContentsFromTags: true,
+    },
     isFormattingEnabled: async (prettier, document, context) => {
       if (!prettier) {
         console.error('[Mpx] prettier is not available')


### PR DESCRIPTION
bug:
prettier.format
```
<template>
  <view class="list">
    <view wx:for="{{listData}}" wx:key="*this">
      {{item}}</view>
  </view>
</template>
```

will become to 

```
<template>
  <view class="list">
    <view wx:for="{{listData}}" wx:key="*this">
      {{item}}</view
    >
  </view>
</template>
```

accept:
prettier.format
```
<template>
  <view class="list">
    <view wx:for="{{listData}}" wx:key="*this">
      {{item}}
    </view>
  </view>
</template>
```
