### PR TITLE
feat: 去除 HTML 内置标签src、href等属性的跳转功能，避免与{{ xxx }}内的路径冲突

### DIFF
--- a/inspect-extension/components/utils/list.mpx
+++ b/inspect-extension/components/utils/list.mpx
@@ -1,10 +1,14 @@
 <template>
-  <image src="{{ imgsrc }}" class="{{ listData }}"></image>
-  <img src="https://mpxjs.cn/assets/logo.png" class="{{ listData }}"></img>
-  <a href="{{ imgsrc }}"></a>
-  <a href="https://mpxjs.cn/assets/logo.png"></a>
-  <a href="/CHANGELOG.md"></a>
-  <view>{{ listData }}</view>
+  <image src="{{ imgsrc }}" class="{{ listData[0] }}"> </image>
+
+  <img src="https://mpxjs.cn/logo.png" class="{{ listData[1] }}" />
+
+  <a href="{{ imgsrc }}"> </a>
+  <a href="{{ 'https://mpxjs.cn/logo.png' }}"> </a>
+  <a href="{{ imgsrc ? imgsrc : 'https://mpxjs.cn/logo.png' }}"> </a>
+  <a href="/CHANGELOG.md"> </a>
+
+  <view> {{ listData }} </view>
 </template>
 
 <script lang="ts">
@@ -12,19 +16,19 @@ import { createComponent } from '@mpxjs/core'
 
 createComponent({
   data: {
-    listData: ['手机', '电视', '电脑']
+    listData: ['class-a', 'class-b', 'class-c'],
   },
   computed: {
     imgsrc() {
       return 'https://mpxjs.cn/assets/logo.png'
-    }
-  }
+    },
+  },
 })
 </script>
 
 <style lang="stylus">
-  .list
-    background-color red
+.list
+  background-color red
 </style>
 
 <script type="application/json">

--- a/packages/language-service/src/plugins/mpx-sfc-template.ts
+++ b/packages/language-service/src/plugins/mpx-sfc-template.ts
@@ -216,16 +216,14 @@ export function create(): LanguageServicePlugin {
         },
 
         /**
-         * 去除 HTML 内置标签src、href等属性的跳转功能，避免与{{ xxx }}内的路径冲突
+         * 去除 HTML 内置标签 src、href 等属性的跳转功能，避免与插值代码 {{ xxx }} 内的变量跳转冲突
          * 比如 <image src="{{ imgsrc }}">、<a href="{{ link }}"> 等等
-         * 这些路径保证跳转至正确变量定义位置即可
          */
         async provideDocumentLinks(document, token) {
           if (document.languageId !== 'html') {
             return
           }
 
-          // 调用原本的 html 插件能力
           const baseLinks = await baseServiceInstance.provideDocumentLinks?.(
             document,
             token,
@@ -235,16 +233,10 @@ export function create(): LanguageServicePlugin {
             return baseLinks
           }
 
-          const text = document.getText()
-
           return baseLinks.filter(link => {
-            const linkText = text.slice(
-              document.offsetAt(link.range.start),
-              document.offsetAt(link.range.end),
-            )
-
-            // 如果包含 {{}}，禁用跳转
-            if (/\{\{.*?\}\}/.test(linkText)) {
+            const linkText = document.getText(link.range)
+            if (/\{\s*\{.*?\}\s*\}/.test(linkText)) {
+              // 如果包含 {{}}，禁用跳转，包括有空格的情况，eg: " { { xx }} "
               return false
             }
             return true


### PR DESCRIPTION
当src、href是插值表达式的时候，html服务还提供了文档链接会导致一个对冲，导致无法跳到正常路径。

因此针对当链接是插值表达式时进行关闭

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List UI now shows images and clickable links and exposes list data for richer item display; image source is provided dynamically.
* **Bug Fixes**
  * Editor link detection in templates improved: links that include template expressions are no longer produced, preventing invalid navigation and reducing noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->