### PR TITLE
Revert "fix: template view break-wrap"

### DIFF
--- a/packages/language-service/src/plugins/mpx-prettier.ts
+++ b/packages/language-service/src/plugins/mpx-prettier.ts
@@ -31,9 +31,6 @@ export function create(): LanguageServicePlugin {
   }
 
   const base = baseCreate(prettierInstanceOrGetter, {
-    html: {
-      breakContentsFromTags: true,
-    },
     isFormattingEnabled: async (prettier, document, context) => {
       if (!prettier) {
         console.error('[Mpx] prettier is not available')


### PR DESCRIPTION
Reverts mpx-ecology/language-tools#63

Closes #72  

这个改动属于额外针对 prettier 某些特殊 case 的能力增强，但是对某些用户可能造成意外的困惑，而且和 prettier cli 不一致的结果也可能带来意外的用户困惑，更重要的是可能影响渲染结果，所以在这里 revert，类似 #63 case 需要用户手动规避（比如手动添加空格），而且此类 case 在 Vue Prettier 中同样存在。

未来如果实现 prettier-plugin-mpx，可以再考虑其中实现类似的定制化增强能力和相关配置选项，这样可以保障 IDE、CLI 一致性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated HTML formatting to rely on default behavior, no longer forcing content to break away from surrounding tags. Users may see fewer unnecessary line breaks and more compact HTML when formatting in the editor or on save. No changes to settings are required, and no public APIs were modified overall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->