### PR TITLE
feat(service): add mpx style directive comments completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "packageManager": "pnpm@10.26.0",
+  "packageManager": "pnpm@10.27.0",
   "scripts": {
     "build": "tsc -b",
     "watch": "pnpm run \"/^watch:.*/\"",

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -19,6 +19,7 @@ import { create as createMpxTemplateDirectiveCommentsPlugin } from './plugins/mp
 import { create as createMpxTemplateLinksPlugin } from './plugins/mpx-sfc-template-links'
 import { create as createMpxStyleCSSPlugin } from './plugins/mpx-sfc-style-css'
 import { create as createMpxStyleStylusPlugin } from './plugins/mpx-sfc-style-stylus'
+import { create as createMpxStyleDirectiveCommentsPlugin } from './plugins/mpx-sfc-style-directive-comments'
 import { create as createMpxJsonJsonPlugin } from './plugins/mpx-sfc-json-json'
 import { create as createMpxJsonLinksPlugin } from './plugins/mpx-sfc-json-links'
 import { create as createMpxPrettierPlugin } from './plugins/mpx-prettier'
@@ -70,6 +71,7 @@ function getCommonLanguageServicePlugins(
     createMpxTemplateAutoinsertSpacePlugin(),
     createMpxStyleCSSPlugin(),
     createMpxStyleStylusPlugin(),
+    createMpxStyleDirectiveCommentsPlugin(),
     // createMpxJsonJsPlugin(ts, getTsPluginClient),
     createMpxJsonJsonPlugin(),
     createMpxTemplateLinksPlugin(),

--- a/packages/language-service/src/plugins/mpx-sfc-style-directive-comments.ts
+++ b/packages/language-service/src/plugins/mpx-sfc-style-directive-comments.ts
@@ -1,0 +1,79 @@
+import type {
+  CompletionItem,
+  LanguageServicePlugin,
+} from '@volar/language-service'
+import type * as vscode from 'vscode-languageserver-protocol'
+import { URI } from 'vscode-uri'
+
+const cmds = ['mpx-if', 'mpx-elif', 'mpx-else', 'mpx-endif']
+
+/**
+ * Mpx style directive comments 样式注释指令补全
+ * e.g. `/* @mpx-if (|) *\/` `/* @mpx-endif *\/` 触发补全
+ */
+export function create(): LanguageServicePlugin {
+  return {
+    name: 'mpx-style-directive-comments',
+
+    capabilities: {
+      completionProvider: {
+        triggerCharacters: ['@'],
+      },
+    },
+
+    create(context) {
+      return {
+        provideCompletionItems(document, position) {
+          const uri = URI.parse(document.uri)
+          const decoded = context.decodeEmbeddedDocumentUri(uri)
+          const sourceScript =
+            decoded && context.language.scripts.get(decoded[0])
+          const virtualCode =
+            decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1])
+          if (
+            !sourceScript?.generated ||
+            !virtualCode?.id.startsWith('style_')
+          ) {
+            return
+          }
+
+          const line = document.getText({
+            start: { line: position.line, character: 0 },
+            end: position,
+          })
+          if (!/^\s*@$/.test(line)) {
+            return
+          }
+
+          const items: CompletionItem[] = cmds.map(label => ({
+            label: `@${label}`,
+            labelDetails: {
+              description: label,
+              detail:
+                label === 'mpx-if' ? '/* @mpx-if ($1) */' : `/* @${label} */`,
+            },
+            kind: 15 satisfies typeof vscode.CompletionItemKind.Snippet,
+            insertTextFormat:
+              2 satisfies typeof vscode.InsertTextFormat.Snippet,
+            textEdit: {
+              range: {
+                start: {
+                  line: position.line,
+                  character: line.lastIndexOf('@'),
+                },
+                end: position,
+              },
+              newText:
+                label === 'mpx-if' ? '/* @mpx-if ($1) */' : `/* @${label} */`,
+            },
+          }))
+
+          return {
+            isIncomplete: false,
+            items,
+          }
+        },
+      }
+    },
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language service auto-completion support for MPX style directive comments. When working with SFC styles, you can now quickly insert @mpx-if, @mpx-elif, @mpx-else, and @mpx-endif directives with auto-suggestion.

* **Chores**
  * Updated package manager to pnpm 10.27.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->