### PR TITLE
feat(typescript-plugin): support go to definition for component props

### DIFF
--- a/inspect-extension/ts-features/ts-go-to-definition/README.md
+++ b/inspect-extension/ts-features/ts-go-to-definition/README.md
@@ -1,0 +1,160 @@
+# Go to Definition 测试用例
+
+本目录包含用于测试"跳转到定义"功能的测试用例。
+
+## 测试场景
+
+### 1. 组件属性跳转到 properties/props 定义
+
+#### Options API 子组件 (`child-component.mpx`)
+
+| 父组件属性    | 预期跳转目标                    |
+| ------------- | ------------------------------- |
+| `title`       | `properties.title`              |
+| `count`       | `properties.count`              |
+| `show-header` | `properties.showHeader`         |
+| `list-data`   | `properties.listData`           |
+| `config`      | `properties.config`             |
+| `name`        | `properties.name` (简写形式)    |
+| `age`         | `properties.age` (简写形式)     |
+| `visible`     | `properties.visible` (简写形式) |
+
+子组件中方法可能定义在不同位置：
+
+| 父组件事件绑定的方法        | 子组件中定义位置     | 预期跳转目标                    |
+| --------------------------- | -------------------- | ------------------------------- |
+| `onMethodsHandler`          | methods 中           | `methods.onMethodsHandler`      |
+| `onTopLevelHandler`         | 顶层（和 data 同级） | `onTopLevelHandler()`           |
+| `onTopLevelHandlerWithArgs` | 顶层（和 data 同级） | `onTopLevelHandlerWithArgs()`   |
+| `onTopLevelArrowHandler`    | 顶层（箭头函数）     | `onTopLevelArrowHandler: () =>` |
+
+#### Composition API 子组件 - 泛型写法 (`child-component-setup.mpx`)
+
+| 父组件属性 | 预期跳转目标                         |
+| ---------- | ------------------------------------ |
+| `message`  | `defineProps<{ message: string }>`   |
+| `visible`  | `defineProps<{ visible: boolean }>`  |
+| `items`    | `defineProps<{ items: string[] }>`   |
+| `optional` | `defineProps<{ optional?: string }>` |
+| `config`   | `defineProps<{ config?: {...} }>`    |
+
+#### Composition API 子组件 - 对象写法 (`child-component-setup-object.mpx`)
+
+| 父组件属性 | 预期跳转目标                        |
+| ---------- | ----------------------------------- |
+| `msg`      | `defineProps({ msg: String })`      |
+| `count`    | `defineProps({ count: Number })`    |
+| `enabled`  | `defineProps({ enabled: Boolean })` |
+
+#### withDefaults 子组件 (`child-component-with-defaults.mpx`)
+
+| 父组件属性 | 预期跳转目标           |
+| ---------- | ---------------------- |
+| `title`    | `Props.title` 类型定义 |
+| `count`    | `Props.count` 类型定义 |
+| `theme`    | `Props.theme` 类型定义 |
+
+### 2. 事件方法跳转
+
+#### 支持的事件绑定语法
+
+| 语法                | 示例                          | 说明                  |
+| ------------------- | ----------------------------- | --------------------- |
+| `bindxxx`           | `bindtap="handler"`           | 绑定事件              |
+| `bind:xxx`          | `bind:tap="handler"`          | 绑定事件（带冒号）    |
+| `catchxxx`          | `catchtap="handler"`          | 捕获事件，阻止冒泡    |
+| `catch:xxx`         | `catch:tap="handler"`         | 捕获事件（带冒号）    |
+| `capture-bind:xxx`  | `capture-bind:tap="handler"`  | 捕获阶段绑定          |
+| `capture-catch:xxx` | `capture-catch:tap="handler"` | 捕获阶段捕获          |
+| `mut-bind:xxx`      | `mut-bind:tap="handler"`      | 互斥事件绑定 (2.8.2+) |
+| 动态绑定            | `bindtap="{{ handlerName }}"` | 方法名是变量          |
+
+#### Options API 父组件 (`parent-component.mpx`)
+
+点击事件处理方法名，应跳转到对应的定义位置：
+
+| 模板中的方法           | 定义位置     | 预期跳转目标                                  |
+| ---------------------- | ------------ | --------------------------------------------- |
+| `onChildChange`        | methods      | `methods.onChildChange`                       |
+| `handleViewTap`        | methods      | `methods.handleViewTap`                       |
+| `handleLongPress`      | methods      | `methods.handleLongPress`                     |
+| `inputBlur`            | methods      | `methods.inputBlur`                           |
+| `handleImageLoad`      | methods      | `methods.handleImageLoad`                     |
+| `setupHandler`         | setup 返回值 | `setup() { return { setupHandler } }`         |
+| `setupHandlerWithArgs` | setup 返回值 | `setup() { return { setupHandlerWithArgs } }` |
+| `dataHandler`          | data         | `data.dataHandler`                            |
+| `computedHandler`      | computed     | `computed.computedHandler`                    |
+
+#### Composition API 父组件 (`parent-component-setup.mpx`)
+
+点击事件处理方法名，应跳转到 `<script setup>` 中对应的函数定义：
+
+| 模板中的方法    | 预期跳转目标                |
+| --------------- | --------------------------- |
+| `onChildChange` | `const onChildChange = ...` |
+| `handleViewTap` | `const handleViewTap = ...` |
+| `inputBlur`     | `const inputBlur = ...`     |
+
+### 3. 特殊场景
+
+#### 带参数的事件处理
+
+```html
+<view bindtap="handleTapWithArgs('arg1', $event)"></view>
+```
+
+点击 `handleTapWithArgs` 应跳转到方法定义。
+
+#### 内联箭头函数
+
+```html
+<view bindtap="{{ () => inlineHandler() }}"></view>
+```
+
+点击 `inlineHandler` 应跳转到方法定义。
+
+#### 属性名转换 (kebab-case -> camelCase)
+
+```html
+<child-component show-header="{{ value }}" />
+```
+
+点击 `show-header` 应跳转到子组件的 `properties.showHeader` 定义。
+
+## 文件说明
+
+| 文件                                | 说明                                           |
+| ----------------------------------- | ---------------------------------------------- |
+| `child-component.mpx`               | Options API 子组件，包含 properties 和 methods |
+| `child-component-setup.mpx`         | Composition API 子组件，使用泛型 defineProps   |
+| `child-component-setup-object.mpx`  | Composition API 子组件，使用对象 defineProps   |
+| `child-component-with-defaults.mpx` | Composition API 子组件，使用 withDefaults      |
+| `parent-component.mpx`              | Options API 父组件 (createComponent)           |
+| `parent-component-setup.mpx`        | Composition API 父组件                         |
+| `parent-page.mpx`                   | Options API 页面 (createPage)                  |
+| `parent-page-setup.mpx`             | Composition API 页面                           |
+
+## 页面 vs 组件
+
+### 页面 (createPage)
+
+页面使用 `createPage` 创建，有以下特点：
+
+- 页面生命周期方法直接定义在顶层：`onLoad`, `onShow`, `onHide`, `onUnload` 等
+- 自定义方法也可以定义在顶层（和生命周期同级）
+- 也可以在 `methods` 中定义方法
+- 可以有 `properties` 接收页面参数
+
+### 组件 (createComponent)
+
+组件使用 `createComponent` 创建，有以下特点：
+
+- 组件生命周期在 `lifetimes` 中定义
+- 方法通常在 `methods` 中定义
+- 也支持顶层定义方法（小程序原生写法）
+
+## 如何测试
+
+1. 在 VSCode 中打开 `parent-component.mpx` 或 `parent-component-setup.mpx`
+2. 按住 `Ctrl` (Windows/Linux) 或 `Cmd` (macOS) 并点击属性名或方法名
+3. 验证是否跳转到正确的定义位置

--- a/inspect-extension/ts-features/ts-go-to-definition/child-component-setup-object.mpx
+++ b/inspect-extension/ts-features/ts-go-to-definition/child-component-setup-object.mpx
@@ -1,0 +1,29 @@
+<template>
+  <view>Child Component (Composition API - Object Style)</view>
+</template>
+
+<script setup lang="ts">
+// defineProps 对象写法（类似 Options API）
+const { msg = 'default msg' } = defineProps({
+  msg: String,
+  count: Number,
+  enabled: Boolean,
+  data: Array,
+  options: Object
+})
+
+const handleClick = () => {
+  console.log('click', msg)
+}
+
+defineExpose({
+  msg,
+  handleClick
+})
+</script>
+
+<script type="application/json">
+{
+  "component": true
+}
+</script>

--- a/inspect-extension/ts-features/ts-go-to-definition/child-component-setup.mpx
+++ b/inspect-extension/ts-features/ts-go-to-definition/child-component-setup.mpx
@@ -1,0 +1,51 @@
+<template>
+  <view>Child Component (Composition API)</view>
+  <view bindtap="handleInternalTap">内部点击</view>
+</template>
+
+<script setup lang="ts">
+// defineProps 泛型写法
+const props = defineProps<{
+  message: string
+  visible: boolean
+  items: string[]
+  // 可选属性
+  optional?: string
+  // 复杂类型
+  config?: {
+    theme: string
+    size: number
+  }
+}>()
+
+// 组件内部方法
+const handleInternalTap = () => {
+  console.log('internal tap', props.message)
+}
+
+// 事件处理方法
+const onUpdate = (value: string) => {
+  console.log('update:', value)
+}
+
+const onClick = () => {
+  console.log('click')
+}
+
+const onCustomEvent = (data: { msg: string }) => {
+  console.log('custom event:', data.msg)
+}
+
+defineExpose({
+  handleInternalTap,
+  onUpdate,
+  onClick,
+  onCustomEvent
+})
+</script>
+
+<script type="application/json">
+{
+  "component": true
+}
+</script>

--- a/inspect-extension/ts-features/ts-go-to-definition/child-component-with-defaults.mpx
+++ b/inspect-extension/ts-features/ts-go-to-definition/child-component-with-defaults.mpx
@@ -1,0 +1,32 @@
+<template>
+  <view>Child Component (withDefaults)</view>
+</template>
+
+<script setup lang="ts">
+// withDefaults 写法
+type Props = {
+  title?: string
+  count?: number
+  theme?: 'light' | 'dark'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  title: 'default title',
+  count: 0,
+  theme: 'light'
+})
+
+const handleAction = () => {
+  console.log('action', props.title)
+}
+
+defineExpose({
+  handleAction
+})
+</script>
+
+<script type="application/json">
+{
+  "component": true
+}
+</script>

--- a/inspect-extension/ts-features/ts-go-to-definition/child-component.mpx
+++ b/inspect-extension/ts-features/ts-go-to-definition/child-component.mpx
@@ -1,0 +1,44 @@
+<template>
+  <view>Child Component (Options API)</view>
+</template>
+
+<script lang="ts">
+import { createComponent } from '@mpxjs/core'
+
+createComponent({
+  properties: {
+    // 基础类型属性 - 完整写法
+    title: {
+      type: String,
+      value: 'default title'
+    },
+    count: {
+      type: Number,
+      value: 0
+    },
+    showHeader: {
+      type: Boolean,
+      value: true
+    },
+    // 复杂类型属性
+    listData: {
+      type: Array,
+      value: [] as string[]
+    },
+    config: {
+      type: Object,
+      value: {} as Record<string, any>
+    },
+    // 简写形式
+    name: String,
+    age: Number,
+    visible: Boolean
+  }
+})
+</script>
+
+<script type="application/json">
+{
+  "component": true
+}
+</script>

--- a/inspect-extension/ts-features/ts-go-to-definition/parent-component-setup.mpx
+++ b/inspect-extension/ts-features/ts-go-to-definition/parent-component-setup.mpx
@@ -1,0 +1,135 @@
+<template>
+  <!-- 
+    Composition API 父组件测试
+    测试 script setup 中定义的方法跳转
+  -->
+
+  <!-- Options API 子组件 -->
+  <child-component
+    title="{{ title }}"
+    count="{{ count }}"
+    show-header="{{ showHeader }}"
+    bind:change="onChildChange"
+    bindtap="onChildTap"
+  />
+
+  <!-- Composition API 子组件 -->
+  <child-component-setup
+    message="{{ message }}"
+    visible="{{ visible }}"
+    items="{{ items }}"
+    bind:update="onChildUpdate"
+    bindclick="onChildClick"
+  />
+
+  <!-- 原生组件事件 -->
+  <view
+    bindtap="handleViewTap"
+    bind:longpress="handleLongPress"
+    catchtap="handleCatchTap"
+    catch:touchstart="handleTouchStart"
+  >
+    点击测试
+  </view>
+
+  <!-- 带参数的事件 -->
+  <view bindtap="handleTapWithArgs('test')">
+    带参数
+  </view>
+
+  <!-- input 事件 -->
+  <input
+    bind:blur="inputBlur"
+    bindfocus="inputFocus"
+    type="text"
+  />
+</template>
+
+<script setup lang="ts">
+// 响应式数据
+const title = 'Hello'
+const count = 10
+const showHeader = true
+const message = 'World'
+const visible = false
+const items = ['a', 'b', 'c']
+
+// 子组件事件处理方法
+const onChildChange = (e: any) => {
+  console.log('child change:', e.detail)
+}
+
+const onChildTap = () => {
+  console.log('child tap')
+}
+
+const onChildUpdate = (value: string) => {
+  console.log('child update:', value)
+}
+
+const onChildClick = () => {
+  console.log('child click')
+}
+
+// 原生组件事件处理方法
+const handleViewTap = () => {
+  console.log('view tap')
+}
+
+const handleLongPress = () => {
+  console.log('long press')
+}
+
+const handleCatchTap = () => {
+  console.log('catch tap')
+}
+
+const handleTouchStart = () => {
+  console.log('touch start')
+}
+
+// 带参数的事件处理
+const handleTapWithArgs = (arg: string) => {
+  console.log('tap with args:', arg)
+}
+
+// input 事件处理
+const inputBlur = (e: any) => {
+  console.log('input blur', e.detail.value)
+}
+
+const inputFocus = (e: any) => {
+  console.log('input focus', e.detail.value)
+}
+
+// 暴露方法给模板使用
+defineExpose({
+  title,
+  count,
+  showHeader,
+  message,
+  visible,
+  items,
+  onChildChange,
+  onChildTap,
+  onChildUpdate,
+  onChildClick,
+  handleViewTap,
+  handleLongPress,
+  handleCatchTap,
+  handleTouchStart,
+  handleTapWithArgs,
+  inputBlur,
+  inputFocus
+})
+</script>
+
+<script type="application/json">
+{
+  "component": true,
+  "usingComponents": {
+    "child-component": "./child-component",
+    "child-component-setup": "./child-component-setup"
+  }
+}
+</script>

--- a/inspect-extension/ts-features/ts-go-to-definition/parent-component.mpx
+++ b/inspect-extension/ts-features/ts-go-to-definition/parent-component.mpx
@@ -1,0 +1,83 @@
+<template>
+  <!-- 
+    ============================================
+    测试场景 1: Options API 子组件属性跳转
+    点击属性名应跳转到子组件的 properties 定义
+    ============================================
+  -->
+  <child-component
+    title="Hello"
+    count="{{ pageCount }}"
+    show-header="{{ showHeader }}"
+    list-data="{{ listData }}"
+    config="{{ config }}"
+    name="test"
+    age="{{ 18 }}"
+    visible="{{ true }}"
+  />
+
+  <!-- 
+    ============================================
+    测试场景 2: Composition API 子组件属性跳转 (泛型写法)
+    点击属性名应跳转到子组件的 defineProps 类型定义
+    ============================================
+  -->
+  <child-component-setup
+    message="World"
+    visible="{{ isVisible }}"
+    items="{{ itemList }}"
+    optional="optional value"
+    config="{{ { theme: 'dark', size: 16 } }}"
+  />
+
+  <!-- 
+    ============================================
+    测试场景 3: Composition API 子组件属性跳转 (对象写法)
+    ============================================
+  -->
+  <child-component-setup-object
+    msg="Hello"
+    count="{{ 10 }}"
+    enabled="{{ true }}"
+    data="{{ [1, 2, 3] }}"
+    options="{{ { key: 'value' } }}"
+  />
+
+  <!-- 
+    ============================================
+    测试场景 4: withDefaults 子组件属性跳转
+    ============================================
+  -->
+  <child-component-with-defaults
+    title="Custom Title"
+    count="{{ 100 }}"
+    theme="dark"
+  />
+</template>
+
+<script lang="ts">
+import { createComponent } from '@mpxjs/core'
+
+createComponent({
+  data: {
+    pageCount: 10,
+    showHeader: true,
+    isVisible: false,
+    itemList: ['a', 'b', 'c'],
+    listData: [1, 2, 3],
+    config: { key: 'value' }
+  }
+})
+</script>
+
+<script type="application/json">
+{
+  "component": true,
+  "usingComponents": {
+    "child-component": "./child-component",
+    "child-component-setup": "./child-component-setup",
+    "child-component-setup-object": "./child-component-setup-object",
+    "child-component-with-defaults": "./child-component-with-defaults"
+  }
+}
+</script>

--- a/inspect-extension/ts-features/ts-go-to-definition/parent-page-setup.mpx
+++ b/inspect-extension/ts-features/ts-go-to-definition/parent-page-setup.mpx
@@ -1,0 +1,89 @@
+<template>
+  <!-- 
+    ============================================
+    页面（Page）测试场景 - Composition API
+    使用 script setup 的页面
+    ============================================
+  -->
+
+  <!-- 子组件属性跳转 -->
+  <child-component
+    title="{{ title }}"
+    count="{{ count }}"
+  />
+
+  <!-- 子组件事件绑定 -->
+  <child-component
+    title="Event Test"
+    bind:change="onChildChange"
+    bindtap="onChildTap"
+  />
+
+  <!-- 原生组件事件 -->
+  <view
+    bindtap="handleViewTap"
+    bind:longpress="handleLongPress"
+  >
+    点击测试
+  </view>
+
+  <!-- input 事件 -->
+  <input
+    bind:blur="inputBlur"
+    bindfocus="inputFocus"
+    type="text"
+  />
+</template>
+
+<script setup lang="ts">
+// 页面数据
+const title = 'Page Setup Test'
+const count = 10
+
+// 子组件事件处理
+const onChildChange = (e: any) => {
+  console.log('child change:', e.detail)
+}
+
+const onChildTap = () => {
+  console.log('child tap')
+}
+
+// 原生组件事件处理
+const handleViewTap = () => {
+  console.log('view tap')
+}
+
+const handleLongPress = () => {
+  console.log('long press')
+}
+
+// input 事件处理
+const inputBlur = (e: any) => {
+  console.log('input blur', e.detail.value)
+}
+
+const inputFocus = (e: any) => {
+  console.log('input focus', e.detail.value)
+}
+
+// 暴露给模板
+defineExpose({
+  title,
+  count,
+  onChildChange,
+  onChildTap,
+  handleViewTap,
+  handleLongPress,
+  inputBlur,
+  inputFocus
+})
+</script>
+
+<script type="application/json">
+{
+  "usingComponents": {
+    "child-component": "./child-component"
+  }
+}
+</script>

--- a/inspect-extension/ts-features/ts-go-to-definition/parent-page.mpx
+++ b/inspect-extension/ts-features/ts-go-to-definition/parent-page.mpx
@@ -1,0 +1,153 @@
+<template>
+  <!-- 
+    ============================================
+    页面（Page）测试场景
+    使用 createPage 创建的页面
+    ============================================
+  -->
+
+  <!-- 子组件属性跳转 -->
+  <child-component
+    title="Page Test"
+    count="{{ pageCount }}"
+    show-header="{{ showHeader }}"
+  />
+
+  <!-- 子组件事件绑定 -->
+  <child-component
+    title="Event Test"
+    bind:change="onChildChange"
+    bindtap="onChildTap"
+  />
+
+  <!-- 原生组件事件 -->
+  <view
+    bindtap="handleViewTap"
+    bind:longpress="handleLongPress"
+    catchtap="handleCatchTap"
+  >
+    点击测试
+  </view>
+
+  <!-- 页面生命周期中定义的方法（顶层方法） -->
+  <view bindtap="onPageMethod">
+    页面顶层方法
+  </view>
+
+  <!-- setup 返回的方法 -->
+  <view bindtap="setupHandler">
+    setup 中的方法
+  </view>
+
+  <!-- methods 中的方法 -->
+  <view bindtap="methodsHandler">
+    methods 中的方法
+  </view>
+
+  <!-- input 事件 -->
+  <input
+    bind:blur="inputBlur"
+    bindfocus="inputFocus"
+    type="text"
+  />
+</template>
+
+<script lang="ts">
+import { createPage } from '@mpxjs/core'
+
+createPage({
+  // 页面可以接收参数作为 properties
+  properties: {
+    pageId: {
+      type: String,
+      value: ''
+    }
+  },
+  data: {
+    pageCount: 10,
+    showHeader: true
+  },
+  setup() {
+    const setupHandler = () => {
+      console.log('handler in setup')
+    }
+    return {
+      setupHandler
+    }
+  },
+  computed: {
+    computedValue() {
+      return this.pageCount * 2
+    }
+  },
+  // 页面生命周期方法（直接定义在顶层）
+  onLoad(options: any) {
+    console.log('page load', options)
+  },
+  onShow() {
+    console.log('page show')
+  },
+  onHide() {
+    console.log('page hide')
+  },
+  onUnload() {
+    console.log('page unload')
+  },
+  onPullDownRefresh() {
+    console.log('pull down refresh')
+  },
+  onReachBottom() {
+    console.log('reach bottom')
+  },
+  onShareAppMessage() {
+    return {
+      title: 'Share Title'
+    }
+  },
+  // 自定义的顶层方法（和生命周期同级）
+  onPageMethod() {
+    console.log('page method at top level')
+  },
+  onCustomTopLevelHandler(arg: string) {
+    console.log('custom top level handler:', arg)
+  },
+  methods: {
+    // 子组件事件处理
+    onChildChange(e: any) {
+      console.log('child change:', e.detail)
+    },
+    onChildTap() {
+      console.log('child tap')
+    },
+    // 原生组件事件处理
+    handleViewTap() {
+      console.log('view tap')
+    },
+    handleLongPress() {
+      console.log('long press')
+    },
+    handleCatchTap() {
+      console.log('catch tap')
+    },
+    // methods 中的方法
+    methodsHandler() {
+      console.log('handler in methods')
+    },
+    // input 事件处理
+    inputBlur(e: any) {
+      console.log('input blur', e.detail.value)
+    },
+    inputFocus(e: any) {
+      console.log('input focus', e.detail.value)
+    }
+  }
+})
+</script>
+
+<script type="application/json">
+{
+  "usingComponents": {
+    "child-component": "./child-component"
+  }
+}
+</script>

--- a/packages/typescript-plugin/src/common.ts
+++ b/packages/typescript-plugin/src/common.ts
@@ -8,7 +8,7 @@ import {
   forEachElementNode,
   hyphenateTag,
 } from '@mpxjs/language-core'
-import { capitalize } from '@mpxjs/language-shared'
+import { camelize, capitalize } from '@mpxjs/language-shared'
 import { _getComponentNames } from './requests/getComponentNames'
 import { _getElementNames } from './requests/getElementNames'
 
@@ -243,10 +243,66 @@ function getDefinitionAndBoundSpan<T>(
       }
     }
 
+    // 从模板位置提取属性名和组件标签名
+    const templateContent = root.sfc.template.content
+    const templateOffset = position - root.sfc.template.startTagEnd
+    const attrInfo = extractAttributeNameAtPosition(
+      templateContent,
+      templateOffset,
+    )
+    const tagInfo = extractTagNameAtPosition(templateContent, templateOffset)
+
+    // 如果在组件属性上（非事件绑定），尝试跳转到子组件的属性定义
+    if (attrInfo && tagInfo && !attrInfo.isEvent) {
+      // 从 usingComponents 中查找子组件路径
+      const componentPath = findComponentPath(
+        root.sfc,
+        tagInfo.tagName,
+        fileName,
+      )
+
+      if (componentPath) {
+        const propDefinition = tryFindComponentPropDefinitionByPath(
+          ts,
+          language,
+          asScriptId,
+          componentPath,
+          attrInfo.attrName,
+        )
+        if (propDefinition) {
+          console.log(
+            '[Mpx Go to Definition] Found prop definition in child component:',
+            JSON.stringify(propDefinition),
+          )
+          definitions.add(propDefinition)
+          // 跳过原始定义
+          for (const def of result.definitions) {
+            skippedDefinitions.push(def)
+          }
+        }
+      }
+    }
+
     for (const definition of result.definitions) {
-      if (
-        mpxOptions.extensions.some(ext => definition.fileName.endsWith(ext))
-      ) {
+      const isMpxFile = mpxOptions.extensions.some(ext =>
+        definition.fileName.endsWith(ext),
+      )
+
+      console.log(
+        '[Mpx Go to Definition] Processing definition:',
+        JSON.stringify({
+          fileName: definition.fileName,
+          textSpan: definition.textSpan,
+          isMpxFile,
+          definitionName: definition.name,
+          definitionKind: definition.kind,
+          containerName: definition.containerName,
+          extensions: mpxOptions.extensions,
+        }),
+      )
+
+      // 跳过已经处理过的组件属性定义
+      if (isMpxFile && attrInfo && tagInfo && !attrInfo.isEvent) {
         continue
       }
 
@@ -314,6 +370,537 @@ function getDefinitionAndBoundSpan<T>(
       }
     }
   }
+}
+
+/**
+ * 从模板内容中提取当前位置的属性名
+ * 支持: title="xxx", show-header="{{ xxx }}", bindtap="handler"
+ */
+function extractAttributeNameAtPosition(
+  templateContent: string,
+  offset: number,
+): { attrName: string; isEvent: boolean } | undefined {
+  // 向前查找属性名的开始位置
+  let start = offset
+  while (start > 0) {
+    const char = templateContent[start - 1]
+    // 属性名可以包含字母、数字、连字符、冒号
+    if (/[a-zA-Z0-9\-:]/.test(char)) {
+      start--
+    } else {
+      break
+    }
+  }
+
+  // 向后查找属性名的结束位置
+  let end = offset
+  while (end < templateContent.length) {
+    const char = templateContent[end]
+    if (/[a-zA-Z0-9\-:]/.test(char)) {
+      end++
+    } else {
+      break
+    }
+  }
+
+  if (start === end) {
+    return undefined
+  }
+
+  const attrName = templateContent.slice(start, end)
+
+  // 检查是否是事件绑定
+  const isEvent = /^(bind|catch|capture-bind|capture-catch|mut-bind):?/.test(
+    attrName,
+  )
+
+  return { attrName, isEvent }
+}
+
+/**
+ * 从模板内容中提取当前位置所在的组件标签名
+ */
+function extractTagNameAtPosition(
+  templateContent: string,
+  offset: number,
+): { tagName: string } | undefined {
+  // 向前查找最近的 < 符号
+  let tagStart = offset
+  while (tagStart > 0) {
+    if (templateContent[tagStart] === '<') {
+      break
+    }
+    // 如果遇到 > 说明不在标签内
+    if (templateContent[tagStart] === '>') {
+      return undefined
+    }
+    tagStart--
+  }
+
+  if (tagStart === 0 && templateContent[0] !== '<') {
+    return undefined
+  }
+
+  // 跳过 < 和可能的 /
+  let nameStart = tagStart + 1
+  if (templateContent[nameStart] === '/') {
+    nameStart++
+  }
+
+  // 提取标签名
+  let nameEnd = nameStart
+  while (nameEnd < templateContent.length) {
+    const char = templateContent[nameEnd]
+    if (/[a-zA-Z0-9\-_]/.test(char)) {
+      nameEnd++
+    } else {
+      break
+    }
+  }
+
+  if (nameStart === nameEnd) {
+    return undefined
+  }
+
+  const tagName = templateContent.slice(nameStart, nameEnd)
+  return { tagName }
+}
+
+/**
+ * 从 SFC 的 JSON 配置中查找组件路径
+ */
+function findComponentPath(
+  sfc: any,
+  tagName: string,
+  currentFileName: string,
+): string | undefined {
+  // 尝试从 script[type="application/json"] 中获取 usingComponents
+  const jsonBlock = sfc.customBlocks?.find(
+    (block: any) =>
+      block.type === 'script' && block.attrs?.type === 'application/json',
+  )
+
+  if (!jsonBlock?.content) {
+    // 也尝试从 sfc.json 获取
+    if (sfc.json?.content) {
+      try {
+        const jsonContent = JSON.parse(sfc.json.content)
+        const componentPath = jsonContent.usingComponents?.[tagName]
+        if (componentPath) {
+          return resolveComponentPath(componentPath, currentFileName)
+        }
+      } catch (e) {
+        console.log('[Mpx Go to Definition] Failed to parse json block:', e)
+      }
+    }
+    return undefined
+  }
+
+  try {
+    const jsonContent = JSON.parse(jsonBlock.content)
+    const componentPath = jsonContent.usingComponents?.[tagName]
+    if (componentPath) {
+      return resolveComponentPath(componentPath, currentFileName)
+    }
+  } catch (e) {
+    console.log('[Mpx Go to Definition] Failed to parse json block:', e)
+  }
+
+  return undefined
+}
+
+/**
+ * 解析组件相对路径为绝对路径
+ */
+function resolveComponentPath(
+  componentPath: string,
+  currentFileName: string,
+): string {
+  // 如果是相对路径，解析为绝对路径
+  if (componentPath.startsWith('./') || componentPath.startsWith('../')) {
+    const currentDir = currentFileName.substring(
+      0,
+      currentFileName.lastIndexOf('/'),
+    )
+    // 简单的路径解析
+    const parts = componentPath.split('/')
+    const currentParts = currentDir.split('/')
+
+    for (const part of parts) {
+      if (part === '.') {
+        continue
+      } else if (part === '..') {
+        currentParts.pop()
+      } else {
+        currentParts.push(part)
+      }
+    }
+
+    let resolvedPath = currentParts.join('/')
+    // 添加 .mpx 扩展名（如果没有）
+    if (!resolvedPath.endsWith('.mpx')) {
+      resolvedPath += '.mpx'
+    }
+    return resolvedPath
+  }
+
+  // 如果是绝对路径或包路径，直接返回
+  return componentPath
+}
+
+/**
+ * 通过组件路径查找属性定义
+ */
+function tryFindComponentPropDefinitionByPath<T>(
+  ts: typeof import('typescript'),
+  language: Language<T>,
+  asScriptId: (fileName: string) => T,
+  componentPath: string,
+  attrName: string,
+): ts.DefinitionInfo | undefined {
+  console.log(
+    '[Mpx Go to Definition] Trying to find prop in component:',
+    JSON.stringify({
+      componentPath,
+      attrName,
+    }),
+  )
+
+  // 获取目标组件的虚拟代码
+  const targetScript = language.scripts.get(asScriptId(componentPath))
+  if (!targetScript?.generated?.root) {
+    console.log(
+      '[Mpx Go to Definition] No target script found for path:',
+      componentPath,
+    )
+    return
+  }
+
+  const targetRoot = targetScript.generated.root
+  if (!(targetRoot instanceof MpxVirtualCode)) {
+    console.log('[Mpx Go to Definition] Target root is not MpxVirtualCode')
+    return
+  }
+
+  // 获取原始 .mpx 文件的 script 内容
+  const sfc = targetRoot.sfc
+  const scriptBlock = sfc.script || sfc.scriptSetup
+  if (!scriptBlock) {
+    console.log(
+      '[Mpx Go to Definition] No script block found in target component',
+    )
+    return
+  }
+
+  console.log(
+    '[Mpx Go to Definition] Target script block info:',
+    JSON.stringify({
+      lang: scriptBlock.lang,
+      startTagEnd: scriptBlock.startTagEnd,
+      endTagStart: scriptBlock.endTagStart,
+      contentLength: scriptBlock.content.length,
+    }),
+  )
+
+  // 在原始脚本内容中查找 properties 定义
+  const propDefinitionOffset = findPropertyDefinitionInScript(
+    ts,
+    scriptBlock.ast,
+    attrName,
+  )
+  if (propDefinitionOffset === undefined) {
+    console.log(
+      '[Mpx Go to Definition] No prop definition found in target script',
+    )
+    return
+  }
+
+  // 计算在原始 .mpx 文件中的位置
+  const absoluteOffset = scriptBlock.startTagEnd + propDefinitionOffset.start
+
+  console.log(
+    '[Mpx Go to Definition] Found prop definition:',
+    JSON.stringify({
+      relativeOffset: propDefinitionOffset,
+      absoluteOffset,
+    }),
+  )
+
+  return {
+    fileName: componentPath,
+    textSpan: {
+      start: absoluteOffset,
+      length: propDefinitionOffset.length,
+    },
+    kind: ts.ScriptElementKind.memberVariableElement,
+    name: attrName,
+    containerName: 'properties',
+    containerKind: ts.ScriptElementKind.classElement,
+  }
+}
+
+/**
+ * 在脚本 AST 中查找 properties 定义
+ * 返回相对于脚本内容的偏移量
+ */
+function findPropertyDefinitionInScript(
+  ts: typeof import('typescript'),
+  scriptAst: ts.SourceFile,
+  propName: string,
+): { start: number; length: number } | undefined {
+  let result: { start: number; length: number } | undefined
+
+  // 将 kebab-case 转换为 camelCase
+  const camelizedPropName = camelize(propName)
+  const possibleNames = [propName, camelizedPropName]
+  if (propName !== camelizedPropName) {
+    possibleNames.push(capitalize(camelizedPropName))
+  }
+
+  function visit(node: ts.Node) {
+    if (result) return
+
+    // 查找 createComponent/createPage/Component 调用
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      ['createComponent', 'createPage', 'Component', 'Page'].includes(
+        node.expression.text,
+      )
+    ) {
+      const arg = node.arguments[0]
+      if (arg && ts.isObjectLiteralExpression(arg)) {
+        // 查找 properties 属性
+        for (const prop of arg.properties) {
+          if (
+            ts.isPropertyAssignment(prop) &&
+            ts.isIdentifier(prop.name) &&
+            prop.name.text === 'properties'
+          ) {
+            if (ts.isObjectLiteralExpression(prop.initializer)) {
+              result = findPropInObjectLiteralAst(
+                ts,
+                scriptAst,
+                prop.initializer,
+                possibleNames,
+              )
+            }
+            break
+          }
+        }
+      }
+    }
+
+    // 查找 defineProps 调用
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'defineProps'
+    ) {
+      // 泛型写法: defineProps<{ propName: string }>() 或 defineProps<Props>()
+      if (node.typeArguments?.length) {
+        const typeArg = node.typeArguments[0]
+        if (
+          ts.isTypeReferenceNode(typeArg) &&
+          ts.isIdentifier(typeArg.typeName)
+        ) {
+          result = findTypeAliasAndPropAst(
+            ts,
+            scriptAst,
+            typeArg.typeName.text,
+            possibleNames,
+          )
+        } else if (ts.isTypeLiteralNode(typeArg)) {
+          result = findPropInTypeLiteralAst(
+            ts,
+            scriptAst,
+            typeArg,
+            possibleNames,
+          )
+        }
+      }
+      // 对象写法: defineProps({ propName: String })
+      else if (node.arguments.length) {
+        const arg = node.arguments[0]
+        if (ts.isObjectLiteralExpression(arg)) {
+          result = findPropInObjectLiteralAst(ts, scriptAst, arg, possibleNames)
+        }
+      }
+    }
+
+    // 查找 withDefaults(defineProps<Props>(), { ... })
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'withDefaults'
+    ) {
+      const definePropsCall = node.arguments[0]
+      if (
+        definePropsCall &&
+        ts.isCallExpression(definePropsCall) &&
+        ts.isIdentifier(definePropsCall.expression) &&
+        definePropsCall.expression.text === 'defineProps'
+      ) {
+        if (definePropsCall.typeArguments?.length) {
+          const typeArg = definePropsCall.typeArguments[0]
+          // 如果是类型引用，需要找到类型定义
+          if (
+            ts.isTypeReferenceNode(typeArg) &&
+            ts.isIdentifier(typeArg.typeName)
+          ) {
+            const typeName = typeArg.typeName.text
+            result = findTypeAliasAndPropAst(
+              ts,
+              scriptAst,
+              typeName,
+              possibleNames,
+            )
+          } else if (ts.isTypeLiteralNode(typeArg)) {
+            result = findPropInTypeLiteralAst(
+              ts,
+              scriptAst,
+              typeArg,
+              possibleNames,
+            )
+          }
+        }
+      }
+    }
+
+    if (!result) {
+      ts.forEachChild(node, visit)
+    }
+  }
+
+  visit(scriptAst)
+  return result
+}
+
+/**
+ * 在对象字面量 AST 中查找属性定义
+ */
+function findPropInObjectLiteralAst(
+  ts: typeof import('typescript'),
+  sourceFile: ts.SourceFile,
+  obj: ts.ObjectLiteralExpression,
+  possibleNames: string[],
+): { start: number; length: number } | undefined {
+  for (const prop of obj.properties) {
+    if (
+      ts.isPropertyAssignment(prop) ||
+      ts.isShorthandPropertyAssignment(prop)
+    ) {
+      const name = prop.name
+      if (ts.isIdentifier(name) && possibleNames.includes(name.text)) {
+        return {
+          start: name.getStart(sourceFile),
+          length: name.getEnd() - name.getStart(sourceFile),
+        }
+      }
+      if (ts.isStringLiteral(name) && possibleNames.includes(name.text)) {
+        return {
+          start: name.getStart(sourceFile),
+          length: name.getEnd() - name.getStart(sourceFile),
+        }
+      }
+    }
+    // 支持方法简写: propName() { ... }
+    if (ts.isMethodDeclaration(prop)) {
+      const name = prop.name
+      if (ts.isIdentifier(name) && possibleNames.includes(name.text)) {
+        return {
+          start: name.getStart(sourceFile),
+          length: name.getEnd() - name.getStart(sourceFile),
+        }
+      }
+    }
+  }
+  return undefined
+}
+
+/**
+ * 在类型字面量 AST 中查找属性定义
+ */
+function findPropInTypeLiteralAst(
+  ts: typeof import('typescript'),
+  sourceFile: ts.SourceFile,
+  typeLiteral: ts.TypeLiteralNode,
+  possibleNames: string[],
+): { start: number; length: number } | undefined {
+  for (const member of typeLiteral.members) {
+    if (ts.isPropertySignature(member)) {
+      const name = member.name
+      if (ts.isIdentifier(name) && possibleNames.includes(name.text)) {
+        return {
+          start: name.getStart(sourceFile),
+          length: name.getEnd() - name.getStart(sourceFile),
+        }
+      }
+      if (ts.isStringLiteral(name) && possibleNames.includes(name.text)) {
+        return {
+          start: name.getStart(sourceFile),
+          length: name.getEnd() - name.getStart(sourceFile),
+        }
+      }
+    }
+  }
+  return undefined
+}
+
+/**
+ * 查找类型别名并在其中查找属性
+ */
+function findTypeAliasAndPropAst(
+  ts: typeof import('typescript'),
+  sourceFile: ts.SourceFile,
+  typeName: string,
+  possibleNames: string[],
+): { start: number; length: number } | undefined {
+  let result: { start: number; length: number } | undefined
+
+  function visit(node: ts.Node) {
+    if (result) return
+
+    if (ts.isTypeAliasDeclaration(node) && node.name.text === typeName) {
+      if (ts.isTypeLiteralNode(node.type)) {
+        result = findPropInTypeLiteralAst(
+          ts,
+          sourceFile,
+          node.type,
+          possibleNames,
+        )
+      }
+    }
+
+    if (ts.isInterfaceDeclaration(node) && node.name.text === typeName) {
+      for (const member of node.members) {
+        if (ts.isPropertySignature(member)) {
+          const name = member.name
+          if (ts.isIdentifier(name) && possibleNames.includes(name.text)) {
+            result = {
+              start: name.getStart(sourceFile),
+              length: name.getEnd() - name.getStart(sourceFile),
+            }
+            return
+          }
+          if (ts.isStringLiteral(name) && possibleNames.includes(name.text)) {
+            result = {
+              start: name.getStart(sourceFile),
+              length: name.getEnd() - name.getStart(sourceFile),
+            }
+            return
+          }
+        }
+      }
+    }
+
+    if (!result) {
+      ts.forEachChild(node, visit)
+    }
+  }
+
+  visit(sourceFile)
+  return result
 }
 
 function getQuickInfoAtPosition(


### PR DESCRIPTION
- Add support for jumping from component attributes to child component's properties definition
- Support Options API (createComponent/createPage/Component/Page)
- Support Composition API (defineProps with generics and object syntax)
- Support withDefaults(defineProps<Props>(), {...}) syntax
- Support kebab-case to camelCase conversion (e.g., show-header → showHeader)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template-aware go-to-definition now resolves child component props and handlers across Options and Composition APIs, handling various binding syntaxes and kebab/camel mappings.

* **Documentation**
  * Added a comprehensive README with step-by-step test cases and validation guidance for go-to-definition scenarios.

* **Tests**
  * Added sample components and pages to exercise prop bindings, events, defaults, and navigation targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->