### PR TITLE
fix: improve UnwrapRefs type to handle optional Ref types

### DIFF
--- a/inspect-extension/components/composition/toRefs.mpx
+++ b/inspect-extension/components/composition/toRefs.mpx
@@ -1,0 +1,24 @@
+<template>
+  <view>
+    <view> msg: {{ b?.c }} </view>
+  </view>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from '@mpxjs/core'
+
+const props = withDefaults(
+  defineProps<{
+    a: { b?: { c?: number } }
+  }>(),
+  {
+    a: {},
+  },
+)
+
+const { b } = toRefs(props.a)
+
+defineExpose({
+  b,
+})
+</script>

--- a/packages/language-core/src/codegen/globalTypes/index.ts
+++ b/packages/language-core/src/codegen/globalTypes/index.ts
@@ -158,10 +158,14 @@ export function generateGlobalTypes({
 	type I18nValues = { [k: string]: string } | Array<string>
 
 	type UnwrapRefs<T> = {
-		[K in keyof T]: T[K] extends import('${lib}').Ref
-			? import('${lib}').UnwrapRef<T[K]>
-			: T[K]
-	}
+    [K in keyof T]: T[K] extends import('${lib}').Ref
+      ? import('${lib}').UnwrapRef<T[K]>
+      : T[K] extends import('${lib}').Ref<infer V> | undefined
+        ? unknown extends V
+          ? undefined
+          : V | undefined
+        : T[K]
+  }
 	${defineComponentTypesContents.globalTypes()}
 }
 ` + defineComponentTypesContents.localTypes(lib)


### PR DESCRIPTION
closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example component demonstrating reactive reference handling for nested properties with optional chaining support.

* **Improvements**
  * Enhanced type system to better handle reactive references that may be undefined, improving type inference accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->