### PR TITLE
fix: enhance handling of MPX directive comments in Stylus formatting

### DIFF
--- a/packages/language-service/src/plugins/mpx-sfc-style-stylus.ts
+++ b/packages/language-service/src/plugins/mpx-sfc-style-stylus.ts
@@ -18,6 +18,10 @@ import {
 const stylusColorRegex =
   /^(\s*)([a-zA-Z][\w-]*)\s*:?\s+(.*?#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})(?![0-9a-fA-F]).*?)$/gm
 
+// Match MPX directive comments like /* @mpx-if (...) */, /* @mpx-elif (...) */, /* @mpx-else */, /* @mpx-endif */
+const mpxDirectiveCommentRegex =
+  /^(\s*)\/\*\s*@mpx-(if|elif|else|endif)\b.*?\*\/\s*$/
+
 export function create(): LanguageServicePlugin {
   const cssBuiltinData = CSS.getDefaultCSSDataProvider()
   const cssData: CSS.CSSDataV1 = {
@@ -81,10 +85,40 @@ export function create(): LanguageServicePlugin {
           }
 
           try {
+            // Extract MPX directive comments before formatting to prevent
+            // stylus-supremacy from moving them to different positions.
+            // Replace with single-line comment placeholders that stay in place.
+            const directiveComments: Map<string, string> = new Map()
+            const lines = stylusContent.split(/\r?\n/)
+            const processedLines = lines.map((line, index) => {
+              if (mpxDirectiveCommentRegex.test(line)) {
+                const placeholder = `// __MPX_DIRECTIVE_${index}__`
+                // Store the trimmed original comment text (without leading whitespace)
+                directiveComments.set(placeholder.trim(), line.trimStart())
+                const indent = line.match(/^(\s*)/)?.[1] ?? ''
+                return indent + placeholder.trim()
+              }
+              return line
+            })
+
+            const processedContent = processedLines.join('\n')
             let newText = stylusSupremacy.format(
-              stylusContent,
+              processedContent,
               formattingOptions,
             )
+
+            // Restore MPX directive comments from placeholders,
+            // keeping the indentation level assigned by the formatter
+            for (const [placeholder, commentText] of directiveComments) {
+              newText = newText.replace(
+                new RegExp(
+                  `^([ \\t]*)${placeholder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`,
+                  'm',
+                ),
+                (_, indent) => indent + commentText,
+              )
+            }
+
             if (initialIndent) {
               newText = newText
                 .split(/\n/)


### PR DESCRIPTION
fix #99 

This pull request enhances the handling of MPX directive comments within Stylus files by ensuring that these comments are preserved in their original positions during formatting. The main improvement is the introduction of logic to temporarily replace MPX directive comments with placeholders before formatting, and then restore them afterward, preventing the formatter from relocating these comments.

Preservation of MPX directive comments during formatting:

* Added a regular expression `mpxDirectiveCommentRegex` to accurately match MPX directive comments such as `/* @mpx-if (...) */` and similar variants.
* Implemented logic to extract MPX directive comments, replace them with unique single-line placeholders before formatting, and restore them after formatting to maintain their original indentation and position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Stylus formatter to properly preserve MPX directive comments in style blocks, maintaining correct indentation and alignment during formatting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->