### PR TITLE
feat(ai): add standalone agent mode and component goToDefinition

### DIFF
--- a/inspect-extension/.vscode/settings.json
+++ b/inspect-extension/.vscode/settings.json
@@ -10,5 +10,5 @@
   "mpx.format.script.prettier": true,
   "mpx.format.template.prettier": true,
   // 方便调试 TM，设置默认现代主题
-  "workbench.colorTheme": "Default Dark Modern"
+  "workbench.colorTheme": "Dark Modern"
 }

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -25,6 +25,7 @@
     "@mpxjs/language-service": "workspace:*",
     "@volar/language-core": "catalog:",
     "@volar/language-server": "catalog:",
+    "volar-service-typescript": "0.0.70",
     "vscode-uri": "catalog:"
   },
   "devDependencies": {

--- a/packages/language-server/src/node.ts
+++ b/packages/language-server/src/node.ts
@@ -1,7 +1,12 @@
 import type { LanguageServer } from '@volar/language-server'
+import type { InitializeParams } from '@volar/language-server'
 import * as ts from 'typescript'
 import { URI } from 'vscode-uri'
-import { createConnection, createServer } from '@volar/language-server/node'
+import {
+  createConnection,
+  createServer,
+  createTypeScriptProject,
+} from '@volar/language-server/node'
 import { createLanguageServiceEnvironment } from '@volar/language-server/lib/project/simpleProject'
 import {
   createLanguage,
@@ -15,6 +20,7 @@ import {
   createMpxLanguageServicePlugins,
   createUriMap,
 } from '@mpxjs/language-service'
+import { create as createTypeScriptSemanticPlugin } from 'volar-service-typescript/lib/plugins/semantic'
 
 const connection = createConnection()
 const server = createServer(connection)
@@ -30,6 +36,51 @@ connection.onNotification('tsserver/response', ([id, response]) => {
 })
 
 connection.onInitialize(params => {
+  if (params.initializationOptions?.agent) {
+    return initializeForAgent(params)
+  }
+  return initializeForIDE(params)
+})
+
+/**
+ * Agent mode: standalone TypeScript project, no tsserver dependency.
+ * Activated via initializationOptions.agent = true.
+ */
+function initializeForAgent(params: InitializeParams) {
+  const plugins = createMpxLanguageServicePlugins(ts, undefined)
+  plugins.push(createTypeScriptSemanticPlugin(ts))
+
+  return server.initialize(
+    params,
+    createTypeScriptProject(ts, undefined, ({ configFileName }) => {
+      const commandLine = configFileName
+        ? createParsedCommandLine(ts, ts.sys, configFileName)
+        : {
+            options: ts.getDefaultCompilerOptions(),
+            mpxOptions: getDefaultCompilerOptions(),
+          }
+      return {
+        languagePlugins: [
+          {
+            getLanguageId: (uri: any) => server.documents.get(uri)?.languageId,
+          },
+          createMpxLanguagePlugin(
+            ts,
+            commandLine.options,
+            commandLine.mpxOptions,
+            (uri: { fsPath: string }) => uri.fsPath.replace(/\\/g, '/'),
+          ),
+        ],
+      }
+    }),
+    plugins,
+  )
+}
+
+/**
+ * IDE mode: delegates TypeScript semantics to IDE's tsserver via notifications.
+ */
+function initializeForIDE(params: InitializeParams) {
   const tsconfigProjects = createUriMap<LanguageService>()
   const file2ProjectInfo = new Map<
     string,
@@ -207,7 +258,7 @@ connection.onInitialize(params => {
       { mpx: { compilerOptions: commonLine.mpxOptions } },
     )
   }
-})
+}
 
 connection.onInitialized(server.initialized)
 

--- a/packages/language-server/src/node.ts
+++ b/packages/language-server/src/node.ts
@@ -47,7 +47,9 @@ connection.onInitialize(params => {
  * Activated via initializationOptions.agent = true.
  */
 function initializeForAgent(params: InitializeParams) {
-  const plugins = createMpxLanguageServicePlugins(ts, undefined)
+  const plugins = createMpxLanguageServicePlugins(ts, undefined, {
+    componentDefinitionProvider: true,
+  })
   plugins.push(createTypeScriptSemanticPlugin(ts))
 
   return server.initialize(

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -24,6 +24,7 @@ import { create as createMpxJsonJsonPlugin } from './plugins/mpx-sfc-json-json'
 import { create as createMpxJsonLinksPlugin } from './plugins/mpx-sfc-json-links'
 import { create as createMpxJsonImportCompletionPlugin } from './plugins/mpx-sfc-json-import-completion'
 import { create as createMpxPrettierPlugin } from './plugins/mpx-prettier'
+import { create as createMpxComponentDefinitionPlugin } from './plugins/mpx-component-definition'
 import { Commands } from './types'
 
 export * from '@volar/language-service'
@@ -77,6 +78,7 @@ function getCommonLanguageServicePlugins(
     createMpxJsonLinksPlugin(),
     createMpxJsonImportCompletionPlugin(getTsPluginClient),
     createMpxPrettierPlugin(),
+    createMpxComponentDefinitionPlugin(),
     createEmmetPlugin({
       mappedLanguages: {
         'mpx-root-tags': 'html',

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -31,6 +31,10 @@ export * from '@volar/language-service'
 export * from '@mpxjs/language-core'
 export * from './types'
 
+export interface MpxLanguageServicePluginOptions {
+  componentDefinitionProvider?: boolean
+}
+
 export function createMpxLanguageServicePlugins(
   ts: typeof import('typescript'),
   tsPluginClient:
@@ -41,8 +45,13 @@ export function createMpxLanguageServicePlugins(
         ) => Promise<ts.DocumentHighlights[] | null>
       })
     | undefined,
+  options: MpxLanguageServicePluginOptions = {},
 ) {
-  const plugins = getCommonLanguageServicePlugins(ts, () => tsPluginClient)
+  const plugins = getCommonLanguageServicePlugins(
+    ts,
+    () => tsPluginClient,
+    options,
+  )
 
   if (tsPluginClient) {
     plugins.push(
@@ -60,8 +69,9 @@ export function createMpxLanguageServicePlugins(
 function getCommonLanguageServicePlugins(
   ts: typeof import('typescript'),
   getTsPluginClient: (context: LanguageServiceContext) => IRequests | undefined,
+  options: MpxLanguageServicePluginOptions,
 ): LanguageServicePlugin[] {
-  return [
+  const plugins: LanguageServicePlugin[] = [
     createTypeScriptSyntacticPlugin(ts),
     createTypeScriptDocCommentTemplatePlugin(ts),
     createMpxSfcPlugin(),
@@ -78,7 +88,9 @@ function getCommonLanguageServicePlugins(
     createMpxJsonLinksPlugin(),
     createMpxJsonImportCompletionPlugin(getTsPluginClient),
     createMpxPrettierPlugin(),
-    createMpxComponentDefinitionPlugin(),
+    ...(options.componentDefinitionProvider
+      ? [createMpxComponentDefinitionPlugin()]
+      : []),
     createEmmetPlugin({
       mappedLanguages: {
         'mpx-root-tags': 'html',
@@ -101,4 +113,5 @@ function getCommonLanguageServicePlugins(
       },
     },
   ]
+  return plugins
 }

--- a/packages/language-service/src/plugins/mpx-component-definition.ts
+++ b/packages/language-service/src/plugins/mpx-component-definition.ts
@@ -1,4 +1,6 @@
 import type { LanguageServicePlugin } from '@volar/language-service'
+import type * as vscode from 'vscode-languageserver-protocol'
+import type { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
 import { MpxVirtualCode, tsCodegen } from '@mpxjs/language-core'
 import { isMpPluginComponentPath } from '../utils'
@@ -40,8 +42,8 @@ export function create(): LanguageServicePlugin {
 
       async function provideJsonDefinition(
         root: MpxVirtualCode,
-        document: any,
-        position: any,
+        document: TextDocument,
+        position: vscode.Position,
       ) {
         if (!root.sfc.json) {
           return
@@ -87,8 +89,8 @@ export function create(): LanguageServicePlugin {
 
       async function provideTemplateDefinition(
         root: MpxVirtualCode,
-        document: any,
-        position: any,
+        document: TextDocument,
+        position: vscode.Position,
       ) {
         const { sfc } = root
         const codegen = tsCodegen.get(sfc)
@@ -103,7 +105,7 @@ export function create(): LanguageServicePlugin {
         const offset = document.offsetAt(position)
 
         for (const { name, startTagOffset, endTagOffset } of templateNodeTags) {
-          if (!usingComponents.has(name) || !startTagOffset) {
+          if (!usingComponents.has(name) || startTagOffset == null) {
             continue
           }
           const onStartTag =

--- a/packages/language-service/src/plugins/mpx-component-definition.ts
+++ b/packages/language-service/src/plugins/mpx-component-definition.ts
@@ -1,0 +1,147 @@
+import type { LanguageServicePlugin } from '@volar/language-service'
+import { URI } from 'vscode-uri'
+import { MpxVirtualCode, tsCodegen } from '@mpxjs/language-core'
+import { isMpPluginComponentPath } from '../utils'
+
+export function create(): LanguageServicePlugin {
+  return {
+    name: 'mpx-component-definition',
+
+    capabilities: {
+      definitionProvider: true,
+    },
+
+    create(context) {
+      return {
+        async provideDefinition(document, position) {
+          const uri = URI.parse(document.uri)
+          const decoded = context.decodeEmbeddedDocumentUri(uri)
+          if (!decoded) {
+            return
+          }
+          const [documentUri, embeddedCodeId] = decoded
+          const sourceScript = context.language.scripts.get(documentUri)
+          const root = sourceScript?.generated?.root
+          if (!(root instanceof MpxVirtualCode)) {
+            return
+          }
+
+          if (/json_(js|json)/.test(embeddedCodeId)) {
+            return provideJsonDefinition(root, document, position)
+          }
+
+          const virtualCode =
+            sourceScript?.generated?.embeddedCodes.get(embeddedCodeId)
+          if (virtualCode?.id === 'template') {
+            return provideTemplateDefinition(root, document, position)
+          }
+        },
+      }
+
+      async function provideJsonDefinition(
+        root: MpxVirtualCode,
+        document: any,
+        position: any,
+      ) {
+        if (!root.sfc.json) {
+          return
+        }
+        const offset = document.offsetAt(position)
+        const { result: resolvedUsingComponents } =
+          (await root.sfc.json.resolvedUsingComponents) || {}
+        if (!resolvedUsingComponents?.size) {
+          return
+        }
+
+        for (const [_, componentsArray] of resolvedUsingComponents) {
+          for (const {
+            text,
+            offset: compOffset,
+            realFilename,
+          } of componentsArray) {
+            if (!realFilename || isMpPluginComponentPath(text)) {
+              continue
+            }
+            if (offset >= compOffset && offset <= compOffset + text.length) {
+              return [
+                {
+                  targetUri: URI.file(realFilename).toString(),
+                  targetRange: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 0 },
+                  },
+                  targetSelectionRange: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 0 },
+                  },
+                  originSelectionRange: {
+                    start: document.positionAt(compOffset),
+                    end: document.positionAt(compOffset + text.length),
+                  },
+                },
+              ]
+            }
+          }
+        }
+      }
+
+      async function provideTemplateDefinition(
+        root: MpxVirtualCode,
+        document: any,
+        position: any,
+      ) {
+        const { sfc } = root
+        const codegen = tsCodegen.get(sfc)
+        const templateNodeTags =
+          codegen?.getGeneratedTemplate()?.templateNodeTags ?? []
+        const { result: usingComponents } =
+          (await sfc.json?.resolvedUsingComponents) || {}
+        if (!usingComponents?.size) {
+          return
+        }
+
+        const offset = document.offsetAt(position)
+
+        for (const { name, startTagOffset, endTagOffset } of templateNodeTags) {
+          if (!usingComponents.has(name) || !startTagOffset) {
+            continue
+          }
+          const onStartTag =
+            offset >= startTagOffset && offset <= startTagOffset + name.length
+          const onEndTag =
+            endTagOffset &&
+            offset >= endTagOffset &&
+            offset <= endTagOffset + name.length
+          if (!onStartTag && !onEndTag) {
+            continue
+          }
+
+          const componentsArray = usingComponents.get(name)!
+          for (const { text, realFilename } of componentsArray) {
+            if (!realFilename || isMpPluginComponentPath(text)) {
+              continue
+            }
+            const tagOffset = onStartTag ? startTagOffset : endTagOffset!
+            return [
+              {
+                targetUri: URI.file(realFilename).toString(),
+                targetRange: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 0, character: 0 },
+                },
+                targetSelectionRange: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 0, character: 0 },
+                },
+                originSelectionRange: {
+                  start: document.positionAt(tagOffset),
+                  end: document.positionAt(tagOffset + name.length),
+                },
+              },
+            ]
+          }
+        }
+      }
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       typescript:
         specifier: '*'
         version: 5.9.2
+      volar-service-typescript:
+        specifier: 0.0.70
+        version: 0.0.70(@volar/language-service@2.4.28)
       vscode-uri:
         specifier: 'catalog:'
         version: 3.1.0


### PR DESCRIPTION
- Add agent mode (initializationOptions.agent=true) using createTypeScriptProject
  + semantic plugin for standalone TS language service without tsserver
- Preserve original IDE mode (simpleProject + sendTsRequest) unchanged
- New mpx-component-definition plugin: definitionProvider for JSON usingComponents paths and template component tags
- Add volar-service-typescript dependency for agent mode

mpx-lsp: https://github.com/lidongsevenlee/sevenlee-claude-code-plugins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone agent mode for TypeScript initialization so the language server can run without IDE TypeScript integration.
  * Added "Go to Definition" navigation for MPX components from templates and component configuration.

* **Chores**
  * Added a pinned TypeScript-related service dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpx-ecology/language-tools/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->