### PR TITLE
fix(core): preserve setup prop types in template context

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,7 @@
       "name": "Attach to Language Server",
       "type": "node",
       "request": "attach",
-      "port": 6009,
+      "port": 6019,
       "restart": true,
       "outFiles": ["${workspaceRoot}/**/*.js"]
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Mpx Language Tools Repository Guide
+
+## Project map
+
+- This is a pnpm monorepo for the Mpx VS Code language tooling. Use the Node and pnpm versions declared in `package.json`.
+- The main dependency flow is `language-shared -> language-core -> typescript-plugin/language-service -> language-server -> vscode`.
+- `packages/language-core` owns Mpx SFC parsing, virtual TypeScript generation, source mappings, template type inference, and generated global types.
+- `packages/typescript-plugin` serves TypeScript-backed component metadata and requests.
+- `packages/language-service` and `packages/language-server` expose editor features over Volar/LSP.
+- `vscode` is the extension client and bundle entry point.
+- `inspect-extension` is the mutable manual integration workspace opened by the F5 Extension Host. It is not a unit-test fixture directory.
+
+## Commands
+
+- Install dependencies with `pnpm install`.
+- Build all TypeScript projects with `pnpm build`.
+- Run the complete test suite with `pnpm test`.
+- Run a focused test with `pnpm exec vitest run <spec-file>`.
+- Run repository linting with `pnpm lint`.
+- Do not edit generated `out`, `dist`, bundled extension JavaScript, or generated global-type files under `node_modules` directly.
+
+## Regression workflow
+
+- For editor-visible bugs, add both layers when practical:
+  1. A deterministic automated fixture and assertion under the owning package's `__tests__` directory.
+  2. A self-contained manual scenario under the matching `inspect-extension` feature directory for F5 validation.
+- Keep automated tests independent from generated output and from the mutable `inspect-extension` workspace.
+- Mark intentional errors in manual `.mpx` scenarios with comments describing the expected diagnostic, hover, completion, navigation, or semantic-token behavior. Do not remove intentional errors merely to make the inspection workspace clean.
+- For language-core changes, run the focused spec first, then `pnpm build`, `pnpm test`, and `pnpm lint`.
+
+## F5 debugging
+
+- The default `VSCode Extension` launch configuration runs the root `watch` task, loads `vscode` as the development extension, disables the installed `mpxjs.mpx-official`, and opens `inspect-extension` in a new Extension Host.
+- After changing server or language-core behavior, wait for the watch build and run `Mpx: Restart Server` in the Extension Host. Restart the Extension Host when extension-client activation or bundling behavior changes.
+- Validate the relevant manual scenario in `inspect-extension` for diagnostics, hover types, completions, definitions/references, and semantic highlighting as applicable.
+- Keep the language-server debug port in `.vscode/launch.json` synchronized with the port passed from `vscode/src/languageClient.ts`.
+
+## Virtual-code changes
+
+- Treat `verification`, `completion`, `semantic`, and `navigation` mapping capabilities independently. A duplicated source mapping can cause duplicate diagnostics, conflicting hover/semantic information, or incorrect navigation even when generated TypeScript compiles.
+- Preserve raw option metadata and source navigation when changing component code generation. Avoid fixing inference by broadly replacing types with `any` or by disabling unrelated mapping capabilities.
+- Changes to generated component/template context should normally test diagnostics and hover information; add mapping or definition assertions when the bug involves semantic tokens or navigation.
+
+## Change hygiene
+
+- Preserve unrelated user changes in the working tree and keep edits scoped to the requested behavior.
+- Do not commit, push, publish, or update changelogs unless the user explicitly asks for that action.

--- a/inspect-extension/components/reference-type-props/component-setup-props.mpx
+++ b/inspect-extension/components/reference-type-props/component-setup-props.mpx
@@ -1,0 +1,76 @@
+<template>
+  <!--
+    Issue #115 manual regression:
+    - correct and incorrect should both hover as Foo.
+    - mixed and mixedIncorrect should both hover as MixedFoo.
+    - Every valid property access should have no diagnostic.
+    - Every no_exist access should report TS2339.
+    - Script semantic highlighting should remain stable when blank lines around
+      properties, mixins, or setup are inserted or removed.
+  -->
+
+  <!-- ✅ properties 直接字段：Foo.exist 存在，预期不报错。 -->
+  <view>{{ correct.exist }}</view>
+
+  <!-- ❌ properties 直接字段：Foo.no_exist 不存在，预期 TS2339。 -->
+  <view>{{ correct.no_exist }}</view>
+
+  <!-- ✅ setup 返回的 computed：应解包为 Foo，访问 exist 预期不报错。 -->
+  <view>{{ incorrect.exist }}</view>
+
+  <!-- ❌ setup 返回的 computed：若没有 TS2339，说明返回值退化成了 any。 -->
+  <view>{{ incorrect.no_exist }}</view>
+
+  <!-- ✅ mixins.properties 直接字段：MixedFoo.mixedExist 存在，预期不报错。 -->
+  <view>{{ mixed.mixedExist }}</view>
+
+  <!-- ❌ mixins.properties 直接字段：MixedFoo.no_exist 不存在，预期 TS2339。 -->
+  <view>{{ mixed.no_exist }}</view>
+
+  <!-- ✅ setup 返回的 mixin computed：应解包为 MixedFoo，预期不报错。 -->
+  <view>{{ mixedIncorrect.mixedExist }}</view>
+
+  <!-- ❌ mixin prop 经 setup/computed 返回后仍应保持类型，预期 TS2339。 -->
+  <view>{{ mixedIncorrect.no_exist }}</view>
+</template>
+
+<script lang="ts">
+import { computed, createComponent, type PropType } from '@mpxjs/core'
+
+type Foo = { exist: string }
+type MixedFoo = { mixedExist: number }
+
+const propsMixin = {
+  properties: {
+    mixed: {
+      type: Object as PropType<MixedFoo>,
+      value: {} as MixedFoo,
+    },
+  },
+}
+
+createComponent({
+  mixins: [propsMixin],
+  properties: {
+    correct: {
+      type: Object as PropType<Foo>,
+      value: {} as Foo,
+    },
+  },
+  setup(props) {
+    // ✅ props.correct 应推断为 Foo；悬浮 correct 可确认类型，预期不报错。
+    const incorrect = computed(() => props.correct)
+
+    // ✅ props.mixed 来自 mixins.properties，应推断为 MixedFoo，预期不报错。
+    const mixedIncorrect = computed(() => props.mixed)
+
+    return { incorrect, mixedIncorrect }
+  },
+})
+</script>
+
+<script type="application/json">
+  {
+    "component": true
+  }
+</script>

--- a/packages/language-core/__tests__/fixtures/reference-type-props/component-setup-props.mpx
+++ b/packages/language-core/__tests__/fixtures/reference-type-props/component-setup-props.mpx
@@ -1,0 +1,38 @@
+<template>
+  <view>{{ correct.no_exist }}</view>
+  <view>{{ incorrect.no_exist }}</view>
+  <view>{{ mixed.no_exist }}</view>
+  <view>{{ mixedIncorrect.no_exist }}</view>
+</template>
+
+<script lang="ts">
+import { computed, createComponent, type PropType } from '@mpxjs/core'
+
+type Foo = { exist: string }
+type MixedFoo = { mixedExist: number }
+
+const propsMixin = {
+  properties: {
+    mixed: {
+      type: Object as PropType<MixedFoo>,
+      value: {} as MixedFoo,
+    },
+  },
+}
+
+createComponent({
+  mixins: [propsMixin],
+  properties: {
+    correct: {
+      type: Object as PropType<Foo>,
+      value: {} as Foo,
+    },
+  },
+  setup(props) {
+    const incorrect = computed(() => props.correct)
+    const mixedIncorrect = computed(() => props.mixed)
+
+    return { incorrect, mixedIncorrect }
+  },
+})
+</script>

--- a/packages/language-core/__tests__/typedComponentProps.spec.ts
+++ b/packages/language-core/__tests__/typedComponentProps.spec.ts
@@ -1,5 +1,6 @@
 import type { RequestContext } from '../../typescript-plugin/src/requests/types'
 import { getComponentProps } from '../../typescript-plugin/src/requests/getComponentProps'
+import type { VirtualCode } from '@volar/language-core'
 import * as ts from 'typescript'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import {
@@ -91,6 +92,76 @@ describe('typed custom component props', () => {
     )
   })
 
+  it('keeps setup returns typed from runtime props without duplicate semantics', () => {
+    const relativePath = 'component-setup-props.mpx'
+    const fileName = service.file(relativePath)
+    const source = service.read(relativePath)
+    const diagnostics = service.proxyLanguageService
+      .getSemanticDiagnostics(fileName)
+      .filter(diagnostic => diagnostic.code === 2339)
+
+    expect(
+      diagnostics.map(diagnostic => diagnosticMessage(diagnostic)),
+    ).toEqual([
+      "Property 'no_exist' does not exist on type 'Foo'.",
+      "Property 'no_exist' does not exist on type 'Foo'.",
+      "Property 'no_exist' does not exist on type 'MixedFoo'.",
+      "Property 'no_exist' does not exist on type 'MixedFoo'.",
+    ])
+
+    const incorrectPosition = source.indexOf('incorrect.no_exist') + 1
+    const incorrectInfo = service.proxyLanguageService.getQuickInfoAtPosition(
+      fileName,
+      incorrectPosition,
+    )
+    expect(displayPartsToString(incorrectInfo?.displayParts)).toBe(
+      '(property) incorrect: Foo',
+    )
+
+    const mixedIncorrectPosition = source.indexOf('mixedIncorrect.no_exist') + 1
+    const mixedIncorrectInfo =
+      service.proxyLanguageService.getQuickInfoAtPosition(
+        fileName,
+        mixedIncorrectPosition,
+      )
+    expect(displayPartsToString(mixedIncorrectInfo?.displayParts)).toBe(
+      '(property) mixedIncorrect: MixedFoo',
+    )
+
+    const mixedPropPosition =
+      source.indexOf('props.mixed') + 'props.'.length + 1
+    const mixedPropInfo = service.proxyLanguageService.getQuickInfoAtPosition(
+      fileName,
+      mixedPropPosition,
+    )
+    expect(displayPartsToString(mixedPropInfo?.displayParts)).toBe(
+      '(property) mixed: MixedFoo',
+    )
+
+    const propsPosition = source.indexOf('props.correct') + 1
+    const propsInfo = service.proxyLanguageService.getQuickInfoAtPosition(
+      fileName,
+      propsPosition,
+    )
+    const propsDisplay = displayPartsToString(propsInfo?.displayParts)
+    expect(propsDisplay).toContain('(parameter) props: GetPropsType<')
+    expect(propsDisplay).not.toContain('(parameter) props: any')
+
+    const { root } = service.getServiceScript(relativePath)
+    const scriptCode = findEmbeddedCode(root, 'script_ts')
+    const semanticMappings = scriptCode?.mappings.flatMap(mapping =>
+      mapping.sourceOffsets.flatMap((sourceOffset, index) => {
+        const length = mapping.lengths[index]
+        return sourceOffset <= propsPosition &&
+          propsPosition < sourceOffset + length &&
+          mapping.data.semantic
+          ? [mapping]
+          : []
+      }),
+    )
+    expect(semanticMappings).toHaveLength(1)
+  })
+
   it('keeps extensionless directory component Props typed', () => {
     const props = getProps('index.mpx', 'component-index')
 
@@ -178,4 +249,19 @@ function displayPartsToString(parts: ts.SymbolDisplayPart[] | undefined) {
 
 function diagnosticMessage(diagnostic: ts.Diagnostic) {
   return ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+}
+
+function findEmbeddedCode(
+  root: VirtualCode,
+  id: string,
+): VirtualCode | undefined {
+  for (const code of root.embeddedCodes ?? []) {
+    if (code.id === id) {
+      return code
+    }
+    const nested = findEmbeddedCode(code, id)
+    if (nested) {
+      return nested
+    }
+  }
 }

--- a/packages/language-core/src/codegen/globalTypes/defineComponentTypes.ts
+++ b/packages/language-core/src/codegen/globalTypes/defineComponentTypes.ts
@@ -3,8 +3,16 @@ import { MpxCompilerOptions } from '../../types'
 // Capture raw options independently from Mpx's constrained inference so IDE
 // metadata remains available even when ComponentIns contains conflicting fields.
 const globalTypes = () => `
-  function __VLS_CaptureOptions<RawO extends Record<string, any>>(
-    opt: RawO & ThisType<__VLS_TemplateContext<RawO>>
+  function __VLS_CaptureOptions<
+    P extends Properties = {},
+    Mi extends Array<any> = [],
+    RawO extends Record<string, any> = Record<string, any>,
+  >(
+    opt: RawO & {
+      properties?: P
+      mixins?: Mi
+      setup?: SetupFunction<P, Mi, any>
+    } & ThisType<__VLS_TemplateContext<RawO>>
   ): RawO
   function __VLS_GetRawProperties<RawO extends Record<string, any>>(
     opt: RawO
@@ -82,6 +90,14 @@ type ObjectOf<T> = {
   [key: string]: T
 }
 type AnyObject = ObjectOf<any>
+type SetupFunction<
+  P extends Properties,
+  Mi extends Array<any>,
+  S,
+> = (
+  props: GetPropsType<P & UnboxMixinsField<Mi, 'properties'>>,
+  context: any
+) => S
 type ThisTypedComponentOpt<
   D extends Data,
   P extends Properties,
@@ -105,7 +121,7 @@ interface ComponentOpt<
   methods?: M
   mixins?: Mi
   watch?: WatchField
-  setup?: (props: GetPropsType<P & UnboxMixinsField<Mi, 'properties'>>, context: any) => S
+  setup?: SetupFunction<P, Mi, S>
   pageShow?: () => void
   pageHide?: () => void
   initData?: Record<string, any>

--- a/packages/language-core/src/codegen/script/index.ts
+++ b/packages/language-core/src/codegen/script/index.ts
@@ -148,6 +148,7 @@ export function* generateScript(
         {
           ...codeFeatures.all,
           verification: false, // 避免重复报错
+          semantic: false, // 避免同一源码区间产生两套语义信息
         },
       )
       yield `)${endOfLine}`


### PR DESCRIPTION
## Summary

- preserve contextual setup(props) typing from component properties and mixins.properties
- reuse a shared SetupFunction type between raw option capture and ComponentOpt
- disable semantic capability on the duplicated raw-options mapping
- add automated and F5 manual regression coverage
- add repository Agent guidance for future editor-visible bugs

## Verification

- pnpm build
- pnpm test (19 tests)
- pnpm lint
- git diff --check

Fixes #115